### PR TITLE
bug fixes, performance improvements, and harness optimisations

### DIFF
--- a/main/__tests__/detail-pane-escape.test.ts
+++ b/main/__tests__/detail-pane-escape.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { esc, formatInline, highlightLine } from '../../src/app/chat/components/ToolCallDetailPane';
+
+describe('esc', () => {
+  it('escapes HTML-significant characters so markup is inert', () => {
+    const out = esc('<img src=x onerror=alert(1)>');
+    expect(out).toContain('&lt;img');
+    expect(out).not.toContain('<img');
+  });
+
+  it('escapes ampersand, angle brackets, and double quotes', () => {
+    expect(esc('&<>"')).toBe('&amp;&lt;&gt;&quot;');
+  });
+
+  it('strips Private Use Area characters', () => {
+    expect(esc('a\uE000b\uF8FFc')).toBe('abc');
+  });
+});
+
+describe('formatInline', () => {
+  it('renders raw HTML tags inert', () => {
+    const out = formatInline('<img src=x onerror=alert(1)>');
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+
+  it('preserves bold formatting', () => {
+    const out = formatInline('**bold**');
+    expect(out).toContain('<strong');
+    expect(out).toContain('</strong>');
+    expect(out).toContain('>bold<');
+  });
+
+  it('preserves inline code formatting', () => {
+    const out = formatInline('`code`');
+    expect(out).toContain('<code');
+    expect(out).toContain('</code>');
+  });
+
+  it('preserves italic formatting alongside plain text', () => {
+    const out = formatInline('a *i* b');
+    expect(out).toContain('<em');
+  });
+
+  it('never emits a raw double quote, keeping injected attributes unbreakable', () => {
+    const out = formatInline('value with "quotes"');
+    expect(out).not.toContain('"');
+  });
+});
+
+describe('highlightLine', () => {
+  it('renders raw HTML tags inert', () => {
+    const out = highlightLine('<img src=x onerror=alert(1)>', 'txt');
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+
+  it('still injects trusted span markup with style attributes', () => {
+    const out = highlightLine('const x = "str"', 'ts');
+    expect(out).toContain('<span style="color: #');
+    expect((out.match(/<span /g) || []).length).toBe((out.match(/<\/span>/g) || []).length);
+  });
+
+  it('leaks no internal placeholder characters for common languages', () => {
+    const inputs = ['const x = "s"', '# heading', '{"k": 1}', 'echo $HOME'];
+    const exts = ['ts', 'md', 'json', 'sh'];
+    inputs.forEach((line, i) => {
+      const out = highlightLine(line, exts[i]);
+      expect(out).not.toMatch(/[\uE000-\uF8FF]/);
+    });
+  });
+
+  it('keeps injected style attributes well-formed across multi-pass highlighting', () => {
+    const html = highlightLine('.foo { color: red; }', 'css');
+    expect(html).not.toContain('style="<');
+    expect(html).not.toContain('=<span');
+    expect((html.match(/<span /g) || []).length).toBe((html.match(/<\/span>/g) || []).length);
+  });
+});

--- a/main/__tests__/document-card-escape.test.ts
+++ b/main/__tests__/document-card-escape.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { esc } from '../../src/app/chat/components/ToolCallDetailPane';
+import { formatInlineText } from '../../src/app/chat/components/DocumentCard';
+
+describe('DocumentCard inline formatting XSS hardening', () => {
+  it('renders raw HTML tags inert in heading/bullet/paragraph pipelines', () => {
+    const out = formatInlineText('<img src=x onerror=alert(1)>', true);
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+    expect(out).not.toMatch(/<(script|img)[\s>]/i);
+  });
+
+  it('escapes markup before bold/code passes so injected attributes cannot break out', () => {
+    const out = formatInlineText('**`<img src=x onerror=alert(1)>`**', false);
+    expect(out).toContain('<strong>');
+    expect(out).toContain('<code');
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+  });
+
+  it('never emits a raw double quote from user text', () => {
+    const out = formatInlineText('" onmouseover="alert(1)" `x` **y**', true);
+    expect(out).not.toContain('" onmouseover');
+    const quotes = out.match(/"/g) || [];
+    quotes.forEach((q) => {
+      expect(out.indexOf(q)).toBeGreaterThan(-1);
+    });
+    expect(out).toContain('&quot;');
+  });
+
+  it('strips Private Use Area placeholder characters', () => {
+    expect(formatInlineText('a\uE000b\uF8FFc', true)).toBe('abc');
+  });
+
+  it('keeps formatter-generated tags as literal trusted HTML', () => {
+    const out = formatInlineText('**bold** and `code`', true);
+    expect(out).toContain('<strong>bold</strong>');
+    expect(out).toMatch(/<code style="background-color: rgba\(255,255,255,0\.08\)[^"]*">code<\/code>/);
+  });
+
+  it('uses the same hardened esc() as ToolCallDetailPane', () => {
+    expect(esc('&<>"')).toBe('&amp;&lt;&gt;&quot;');
+    expect(formatInlineText('&<>"', true)).toBe('&amp;&lt;&gt;&quot;');
+  });
+});

--- a/main/__tests__/history-parse.test.ts
+++ b/main/__tests__/history-parse.test.ts
@@ -1,0 +1,70 @@
+/**
+ * parseJsonField — defensive JSON column parser used by ChatHistoryStore.load().
+ *
+ * Contract: one corrupted column must never null out a whole conversation.
+ * Corrupt JSON -> fallback + console.warn; null/undefined -> silent fallback;
+ * valid payloads pass through unchanged. The helper is exercised directly
+ * (exported for testability); its call sites in load() rely on exactly this
+ * behavior per-field (tool_calls / mission_timeline / attachments).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../lib/db', () => ({
+  dbOps: { run: vi.fn(), get: vi.fn(), all: vi.fn(async () => []) },
+}));
+vi.mock('../lib/embeddings', () => ({
+  getSystemEmbeddingConfig: vi.fn(async () => ({})),
+  getEmbeddingModel: vi.fn(() => 'test-model'),
+}));
+
+import { parseJsonField } from '../store/history';
+
+describe('parseJsonField', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns fallback and warns on corrupt JSON', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fallback: any[] = [];
+
+    const result = parseJsonField<any[]>('{not valid json,,', fallback, 'attachments');
+
+    expect(result).toBe(fallback);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [labelArg, errArg] = warnSpy.mock.calls[0];
+    expect(String(labelArg)).toContain('Corrupt');
+    expect(String(labelArg)).toContain('attachments');
+    // history.ts passes err instanceof Error ? err.message : err
+    expect(typeof errArg).toBe('string');
+    expect(String(errArg)).toMatch(/JSON|property|token/i);
+  });
+
+  it('returns fallback silently for null/undefined (no warn)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseJsonField(null, 'fb-null', 'tool_calls')).toBe('fb-null');
+    expect(parseJsonField(undefined, 'fb-undef', 'tool_calls')).toBe('fb-undef');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes valid JSON through with types preserved', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseJsonField('{"a":1}', undefined as any, 'mission_timeline')).toEqual({ a: 1 });
+    expect(parseJsonField('[1,"two",{"three":3}]', [], 'attachments')).toEqual([
+      1,
+      'two',
+      { three: 3 },
+    ]);
+    expect(parseJsonField('true', false, 'flag')).toBe(true);
+    expect(parseJsonField('42', 0, 'count')).toBe(42);
+    expect(parseJsonField('"hello"', '', 'title')).toBe('hello');
+
+    // Fallback identity is only substituted on failure — literal 'null' parses through
+    const fb = { keep: true };
+    expect(parseJsonField('null', fb, 'x')).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/main/__tests__/hitl-preload-contract.test.ts
+++ b/main/__tests__/hitl-preload-contract.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Static contract test for preload/preload.ts stream cleanup.
+ *
+ * Regression lock: removeStreamListeners() must NOT tear down the
+ * 'acp:hitl-request' listener. The chat page registers that listener once at
+ * mount and relies on it surviving mid-stream resets; a blanket
+ * removeAllListeners('acp:hitl-request') inside removeStreamListeners kills
+ * HITL permission cards after the first send/reset cycle.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Same source-reading convention as preload/__tests__/preload-api-structure.test.ts:
+// resolve relative to this spec file rather than process.cwd().
+const PRELOAD_PATH = path.join(__dirname, '..', '..', 'preload', 'preload.ts');
+const source: string = fs.readFileSync(PRELOAD_PATH, 'utf-8');
+
+/** Extracts the body of the first removeStreamListeners implementation. */
+function extractRemoveStreamListenersBlock(src: string): string {
+  const startMarker = 'removeStreamListeners: () => {';
+  const start = src.indexOf(startMarker);
+  if (start === -1) throw new Error(`removeStreamListeners impl not found in ${PRELOAD_PATH}`);
+  const end = src.indexOf('\n    },', start);
+  if (end === -1) throw new Error('removeStreamListeners block is not closed as expected');
+  return src.slice(start, end);
+}
+
+describe('preload removeStreamListeners contract', () => {
+  const block = extractRemoveStreamListenersBlock(source);
+
+  it("does NOT removeAllListeners('acp:hitl-request') inside removeStreamListeners", () => {
+    expect(block).not.toContain("removeAllListeners('acp:hitl-request')");
+  });
+
+  it("still removes the actual stream channels (block extraction is sound)", () => {
+    expect(block).toContain("removeAllListeners('acp:stream-chunk')");
+    expect(block).toContain("removeAllListeners('acp:thought')");
+    expect(block).toContain("removeAllListeners('acp:tool-call-complete')");
+    expect(block).toContain('acp:hitl-request is intentionally NOT removed');
+  });
+
+  it("the file still registers 'acp:hitl-request' elsewhere (right file under test)", () => {
+    expect(source).toContain("ipcRenderer.on('acp:hitl-request'");
+  });
+});

--- a/main/__tests__/metadata-guard.test.ts
+++ b/main/__tests__/metadata-guard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * WAVE-5R — SSRF + open-path guards for system:fetch-metadata / system:open-external.
+ *
+ * Pins the pure validators exported from window-fs-handlers:
+ * - parseIpAddress expands literal-IP shorthand (decimal/hex/octal integers,
+ *   IPv4-mapped IPv6) so isPrivateAddress can catch hosts like 2130706433
+ *   or ::ffff:169.254.169.254 that the old string-prefix screen let through.
+ * - assertPublicHost rejects when DNS resolution lands in private/reserved
+ *   space (post-resolution check; the example.com case is network-dependent
+ *   and self-skips if DNS is unavailable).
+ * - isSafeLocalOpenPath denies executable payloads (.exe & co — openPath goes
+ *   through ShellExecute/LaunchServices and would LAUNCH them) plus the macOS
+ *   /private/etc and /private/var/root aliases of sensitive dirs.
+ */
+
+import { describe, it, expect, vi, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as dns from 'dns';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  dialog: {},
+  shell: {},
+  app: {},
+}));
+vi.mock('../agent/tools/memory-save', () => ({ memorySaveTool: {} }));
+
+import {
+  parseIpAddress,
+  isPrivateAddress,
+  assertPublicHost,
+  isSafeLocalOpenPath,
+} from '../ipc/system/window-fs-handlers';
+
+describe('WAVE-5R literal-host expansion (parseIpAddress / isPrivateAddress)', () => {
+  it('decimal integer v4 maps to loopback (2130706433)', () => {
+    expect(parseIpAddress('2130706433')).toEqual([127, 0, 0, 1]);
+    expect(isPrivateAddress(parseIpAddress('2130706433'))).toBe(true);
+  });
+
+  it('hex integer v4 maps to loopback (0x7f000001)', () => {
+    expect(parseIpAddress('0x7f000001')).toEqual([127, 0, 0, 1]);
+    expect(isPrivateAddress(parseIpAddress('0x7f000001'))).toBe(true);
+  });
+
+  it('IPv4-mapped IPv6 link-local is rejected (::ffff:169.254.169.254)', () => {
+    expect(isPrivateAddress(parseIpAddress('::ffff:169.254.169.254'))).toBe(true);
+  });
+
+  it('public v4 passes (8.8.8.8)', () => {
+    expect(isPrivateAddress(parseIpAddress('8.8.8.8'))).toBe(false);
+  });
+
+  it('reserved ranges are rejected', () => {
+    for (const addr of ['10.1.2.3', '172.16.0.1', '192.168.1.1', '169.254.169.254',
+      '100.64.0.1', '0.0.0.0', '::1', 'fd00::1', 'fe80::1']) {
+      expect(isPrivateAddress(parseIpAddress(addr))).toBe(true);
+    }
+  });
+
+  it('non-literal hostnames do not parse as addresses', () => {
+    expect(parseIpAddress('example.com')).toBeNull();
+    expect(isPrivateAddress(null)).toBe(true);
+  });
+});
+
+describe('WAVE-5R post-resolution guard (assertPublicHost)', () => {
+  it('link-local literal is rejected without network', async () => {
+    await expect(assertPublicHost('169.254.169.254')).rejects.toThrow();
+  });
+
+  it('loopback literal is rejected', async () => {
+    await expect(assertPublicHost('127.0.0.1')).rejects.toThrow();
+  });
+
+  it('example.com resolves public (network-dependent)', async (ctx) => {
+    let records;
+    try {
+      records = await dns.promises.lookup('example.com', { all: true, verbatim: true });
+    } catch {
+      return ctx.skip();
+    }
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(isPrivateAddress(parseIpAddress(record.address))).toBe(false);
+    }
+  });
+});
+
+describe('WAVE-5R open-path validator (isSafeLocalOpenPath)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'everfern-metadata-guard-'));
+
+  it('rejects executable payloads regardless of extension casing', () => {
+    const p = path.join(tmp, 'payload.EXE');
+    fs.writeFileSync(p, 'MZ');
+    expect(isSafeLocalOpenPath(p)).toBe(false);
+  });
+
+  it('rejects script/installer formats (.bat .ps1 .app .deb)', () => {
+    for (const ext of ['.bat', '.ps1', '.app', '.deb']) {
+      const p = path.join(tmp, `payload${ext}`);
+      fs.writeFileSync(p, '');
+      expect(isSafeLocalOpenPath(p)).toBe(false);
+    }
+  });
+
+  it('denies /private/etc and /private/var/root (macOS aliases)', () => {
+    expect(isSafeLocalOpenPath('/etc/hosts')).toBe(false);
+    expect(isSafeLocalOpenPath('/private/etc/hosts')).toBe(false);
+    expect(isSafeLocalOpenPath('/private/var/root/secret.txt')).toBe(false);
+  });
+
+  it('admits benign existing files', () => {
+    const p = path.join(tmp, 'notes.txt');
+    fs.writeFileSync(p, 'hello');
+    expect(isSafeLocalOpenPath(p)).toBe(true);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/main/__tests__/ollama-schema-sanitizer.test.ts
+++ b/main/__tests__/ollama-schema-sanitizer.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Ollama tool-schema sanitizer (_formatOllamaTools).
+ *
+ * Ollama's native /api/chat rejects schemas containing:
+ * - boolean `required` on properties (must be hoisted to the parent's required[])
+ * - array-typed `type` unions like ["string","null"]
+ * - $schema/$id/examples meta keys
+ *
+ * These specs lock the sanitizer against all nesting shapes: depth 1/2/3
+ * properties, items.properties, anyOf branches, unions and $schema keys.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { _formatOllamaTools } from '../lib/ai-client';
+
+/** Deep-walks any JS value, returning every object node reachable (cycle-safe). */
+function allObjectNodes(root: any): any[] {
+  const out: any[] = [];
+  const seen = new Set<any>();
+  const visit = (node: any) => {
+    if (!node || typeof node !== 'object') return;
+    if (seen.has(node)) return;
+    seen.add(node);
+    out.push(node);
+    for (const key of Object.keys(node)) visit(node[key]);
+  };
+  visit(root);
+  return out;
+}
+
+function countBooleanRequireds(formatted: any[]): number {
+  return allObjectNodes(formatted).filter((n) => typeof n.required === 'boolean').length;
+}
+
+function countArrayTypes(formatted: any[]): number {
+  return allObjectNodes(formatted).filter((n) => Array.isArray(n.type)).length;
+}
+
+function countMetaKeys(formatted: any[]): number {
+  return allObjectNodes(formatted).filter(
+    (n) => '$schema' in n || '$id' in n || 'examples' in n
+  ).length;
+}
+
+describe('_formatOllamaTools schema sanitization', () => {
+  it('hoists depth-1 boolean required, collapses type unions, strips $schema', () => {
+    const tools = [
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'Search things',
+          parameters: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              query: { type: ['string', 'null'], required: true },
+              limit: { type: 'number' },
+            },
+          },
+        },
+      },
+    ];
+
+    const out = _formatOllamaTools(tools);
+
+    // Root envelope shape intact
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      type: 'function',
+      function: {
+        name: 'search',
+        description: 'Search things',
+        parameters: expect.objectContaining({
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+        }),
+      },
+    });
+
+    // Zero boolean requireds / array types / meta keys anywhere in the tree
+    expect(countBooleanRequireds(out)).toBe(0);
+    expect(countArrayTypes(out)).toBe(0);
+    expect(countMetaKeys(out)).toBe(0);
+
+    // Valid required[] hoisting
+    expect(out[0].function.parameters.required).toEqual(['query']);
+    const props = out[0].function.parameters.properties;
+    expect(props.query.type).toBe('string'); // ["string","null"] -> first non-null
+  });
+
+  it('sanitizes boolean required at depth 2 and 3 inside nested properties', () => {
+    const tools = [
+      {
+        name: 'nested',
+        parameters: {
+          type: 'object',
+          properties: {
+            filter: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', required: true },
+                range: {
+                  type: 'object',
+                  properties: {
+                    min: { type: 'number', required: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const out = _formatOllamaTools(tools);
+    expect(countBooleanRequireds(out)).toBe(0);
+
+    const params = out[0].function.parameters;
+    expect(params.properties.filter.properties.name.required).toBeUndefined();
+    expect(params.properties.filter.required).toEqual(['name']);
+    expect(params.properties.filter.properties.range.required).toEqual(['min']);
+
+    // No stray required entries introduced at the root where nothing was required
+    expect(Array.isArray(params.required)).toBe(true);
+    expect(params.required).toEqual([]);
+  });
+
+  it('descends into items.properties and hoists there', () => {
+    const tools = [
+      {
+        name: 'tag',
+        parameters: {
+          type: 'object',
+          properties: {
+            tags: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: ['number', 'null'], required: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const out = _formatOllamaTools(tools);
+    expect(countBooleanRequireds(out)).toBe(0);
+    expect(countArrayTypes(out)).toBe(0);
+
+    const tags = out[0].function.parameters.properties.tags;
+    expect(tags.items.required).toEqual(['id']);
+    expect(tags.items.properties.id.type).toBe('number');
+  });
+
+  it('sanitizes inside anyOf branches (and leaves non-object branches intact)', () => {
+    const tools = [
+      {
+        name: 'flexible',
+        parameters: {
+          type: ['object', 'null'],
+          properties: {
+            target: {
+              anyOf: [
+                {
+                  type: 'object',
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  properties: { mode: { type: 'string', required: true } },
+                },
+                { type: 'null' },
+              ],
+            },
+          },
+        },
+      },
+    ];
+
+    const out = _formatOllamaTools(tools);
+    expect(countBooleanRequireds(out)).toBe(0);
+    expect(countArrayTypes(out)).toBe(0);
+    expect(countMetaKeys(out)).toBe(0);
+
+    const params = out[0].function.parameters;
+    expect(params.type).toBe('object'); // union collapsed
+    const branch = params.properties.target.anyOf[0];
+    expect(branch.required).toEqual(['mode']);
+    expect(branch.properties.mode.required).toBeUndefined();
+    expect(params.properties.target.anyOf[1]).toEqual({ type: 'null' });
+  });
+
+  it('handles mixed batches of bare and enveloped tool definitions', () => {
+    const out = _formatOllamaTools([
+      { name: 'bare', parameters: { type: 'object', properties: {} } },
+      {
+        type: 'function',
+        function: {
+          name: 'wrapped',
+          description: '',
+          parameters: {
+            type: 'object',
+            properties: { q: { type: 'string', required: true } },
+          },
+        },
+      },
+    ]);
+
+    expect(out.map((t: any) => t.function.name)).toEqual(['bare', 'wrapped']);
+    expect(countBooleanRequireds(out)).toBe(0);
+    expect(out[1].function.parameters.required).toEqual(['q']);
+    for (const t of out) {
+      expect(t.type).toBe('function');
+      expect(typeof t.function.name).toBe('string');
+      expect(t.function.parameters).toEqual(
+        expect.objectContaining({
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+        })
+      );
+    }
+  });
+});

--- a/main/__tests__/path-guard.test.ts
+++ b/main/__tests__/path-guard.test.ts
@@ -1,0 +1,312 @@
+/**
+ * MP-SEC-02 — sandboxed path handling (main/lib/path-guard).
+ *
+ * Contract:
+ * - resolveWithin(root, ...segments) resolves segments under root, rejecting
+ *   lexical escapes ('..' climbs, absolute overrides) with "Path escapes
+ *   sandbox root: ..." and symlink escapes with "... via symlink: ...".
+ *   Existing targets are realpath'd before the containment re-check. Missing
+ *   targets ENOENT on realpath; lstat disambiguates: a genuinely absent target
+ *   (lazy first write) falls back to the lexically-checked resolution, while a
+ *   dangling symlink (which a later write would FOLLOW out of the root) throws
+ *   "... via dangling symlink". A child equal to its parent counts as contained.
+ * - assertSafeSegment(segment, label) admits only 1..120 chars of
+ *   [A-Za-z0-9._-] with no '..' substring; anything else throws
+ *   "Unsafe <label>: <first 40 chars>".
+ *
+ * The final describe proves the store layer (artifacts/sites) is closed
+ * end-to-end by mocking os.homedir() at a tmp fixture home BEFORE the stores
+ * evaluate their module-level SITES_DIR / ARTIFACTS_DIR consts.
+ *
+ * Fixture hygiene: every fixture lives under os.tmpdir(); nothing is created
+ * inside the repo. Roots are passed through fs.realpathSync because on macOS
+ * TMPDIR (/var/...) resolves to /private/var/... and the guard compares
+ * lexical resolutions against realpaths — mixing the two would false-positive.
+ */
+
+import { describe, it, expect, vi, afterEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Hoisted state shared with the hoisted vi.mock factory below: the fixture
+// home is created inside the factory (which runs before store imports) so the
+// stores' module-level os.homedir() calls pick it up.
+const fixtureHome = vi.hoisted(() => ({ home: null as string | null }));
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  const fsMod = await import('fs');
+  const pathMod = await import('path');
+  const raw = fsMod.mkdtempSync(pathMod.join(actual.tmpdir(), 'everfern-fixture-home-'));
+  // Use the realpath: on macOS /var is a symlink to /private/var, and the
+  // guard's lexical-vs-realpath checks must not straddle that boundary.
+  fixtureHome.home = fsMod.realpathSync(raw);
+  return { ...actual, homedir: () => fixtureHome.home as string };
+});
+
+import { assertSafeSegment, resolveWithin } from '../lib/path-guard';
+import { writeArtifact } from '../store/artifacts';
+import { deleteSite, writeSiteFile } from '../store/sites';
+
+// ---------------------------------------------------------------------------
+// Direct unit fixtures
+// ---------------------------------------------------------------------------
+
+const tmpRoots: string[] = [];
+
+function makeTmpRoot(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'everfern-path-guard-'));
+  tmpRoots.push(dir);
+  return fs.realpathSync(dir);
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
+  if (fixtureHome.home) {
+    fs.rmSync(fixtureHome.home, { recursive: true, force: true });
+    fixtureHome.home = null;
+  }
+});
+
+describe('assertSafeSegment', () => {
+  it('accepts typical single-segment identifiers', () => {
+    expect(assertSafeSegment('abc123')).toBe('abc123');
+    expect(assertSafeSegment('chat_9f-8.x')).toBe('chat_9f-8.x');
+    expect(assertSafeSegment('a')).toBe('a');
+    const long120 = 'a'.repeat(120);
+    expect(assertSafeSegment(long120)).toBe(long120);
+  });
+
+  it('rejects traversal, absolute paths, separators and empty input', () => {
+    expect(() => assertSafeSegment('../../x')).toThrow(/Unsafe identifier/);
+    expect(() => assertSafeSegment('/etc/passwd')).toThrow(/Unsafe identifier/);
+    expect(() => assertSafeSegment('a/b')).toThrow(/Unsafe identifier/);
+    expect(() => assertSafeSegment('..')).toThrow(/Unsafe identifier/);
+    expect(() => assertSafeSegment('')).toThrow(/Unsafe identifier/);
+  });
+
+  it('rejects strings containing ".." anywhere', () => {
+    expect(() => assertSafeSegment('a..b')).toThrow(/Unsafe identifier/);
+    expect(() => assertSafeSegment('..hidden')).toThrow(/Unsafe identifier/);
+  });
+
+  it('rejects over-length identifiers at the 121st char', () => {
+    expect(() => assertSafeSegment('a'.repeat(121))).toThrow(/Unsafe identifier/);
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => (assertSafeSegment as any)(42)).toThrow(/Unsafe identifier/);
+    expect(() => (assertSafeSegment as any)(null)).toThrow(/Unsafe identifier/);
+    expect(() => (assertSafeSegment as any)(undefined)).toThrow(/Unsafe identifier/);
+  });
+
+  it('uses the supplied label in the error message', () => {
+    expect(() => assertSafeSegment('../x', 'chat id')).toThrow(/Unsafe chat id/);
+  });
+
+  // ANOMALY vs spec: '.' satisfies [A-Za-z0-9._-]+ at length 1, so the current
+  // guard ACCEPTS it. Pinning observed behavior here; '.' resolves to the root
+  // itself in resolveWithin, so this is hygiene-level, not an escape vector.
+  it('currently accepts "." (documented deviation from intended contract)', () => {
+    expect(assertSafeSegment('.')).toBe('.');
+  });
+});
+
+describe('resolveWithin — valid round-trips', () => {
+  it('returns the realpath of an existing file inside root', () => {
+    const root = makeTmpRoot();
+    const file = path.join(root, 'report.html');
+    fs.writeFileSync(file, '<html></html>');
+    const result = resolveWithin(root, 'report.html');
+    expect(result).toBe(fs.realpathSync(file));
+    expect(result).toBe(file);
+  });
+
+  it('resolves nested segments when intermediate dirs exist', () => {
+    const root = makeTmpRoot();
+    fs.mkdirSync(path.join(root, 'sub'));
+    const result = resolveWithin(root, 'sub', 'file.txt');
+    expect(result).toBe(path.join(root, 'sub', 'file.txt'));
+    expect(result.startsWith(root + path.sep)).toBe(true);
+  });
+
+  it('resolves a not-yet-existing file under root without throwing', () => {
+    const root = makeTmpRoot();
+    expect(resolveWithin(root, 'newfile.html')).toBe(path.join(root, 'newfile.html'));
+  });
+
+  it('returns root itself when no segments are given (child === parent)', () => {
+    const root = makeTmpRoot();
+    expect(resolveWithin(root)).toBe(root);
+  });
+});
+
+describe('resolveWithin — traversal rejection', () => {
+  it('throws on ".." climbs out of the root', () => {
+    const root = makeTmpRoot();
+    expect(() => resolveWithin(root, '../../x')).toThrow(/escapes sandbox root/);
+  });
+
+  it('throws when an absolute segment overrides the root', () => {
+    const root = makeTmpRoot();
+    expect(() => resolveWithin(root, '/etc/passwd')).toThrow(/escapes sandbox root/);
+  });
+
+  it('throws when nested segments combine into an escape', () => {
+    const root = makeTmpRoot();
+    expect(() => resolveWithin(root, 'sub', '../../../etc/passwd')).toThrow(
+      /escapes sandbox root/
+    );
+  });
+});
+
+describe('resolveWithin — symlink escape (MP-SEC-02 regression)', () => {
+  it('rejects a link planted inside the sandbox pointing at a sibling outside it', () => {
+    const area = makeTmpRoot();
+    const sandbox = path.join(area, 'sandbox');
+    fs.mkdirSync(sandbox);
+    const outside = path.join(area, 'outside');
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'top secret');
+    // Relative dir symlink: area/sandbox/link -> ../outside
+    fs.symlinkSync(path.join('..', 'outside'), path.join(sandbox, 'link'), 'dir');
+
+    expect(() => resolveWithin(sandbox, 'link', 'secret.txt')).toThrow(
+      /escapes sandbox root/
+    );
+  });
+
+  it('still admits real files reached without symlinks (no over-blocking)', () => {
+    const area = makeTmpRoot();
+    const sandbox = path.join(area, 'sandbox');
+    fs.mkdirSync(sandbox);
+    fs.writeFileSync(path.join(sandbox, 'real.html'), '<html>ok</html>');
+
+    const result = resolveWithin(sandbox, 'real.html');
+    expect(result).toBe(fs.realpathSync(path.join(sandbox, 'real.html')));
+    expect(result.startsWith(fs.realpathSync(sandbox))).toBe(true);
+  });
+
+  // darwin permits /tmp-relative links, so the sibling-link case above fully
+  // covers the physical escape; a fully-outside-tmp link adds nothing there.
+});
+
+// MP-SEC-02 regression: a DANGLING link planted inside the sandbox used to slip
+// through resolveWithin's ENOENT fallback (realpathSync fails identically for
+// a missing file and a broken link), so a subsequent write would FOLLOW the
+// link and land outside the root. The fix lstats on realpath ENOENT; these
+// tests pin both the refusal and the guarantee that nothing is written out.
+describe('resolveWithin — dangling symlink escape (write-follow regression)', () => {
+  it('throws on a dangling link while still resolving genuinely absent paths lexically', () => {
+    const area = makeTmpRoot();
+    const sandbox = path.join(area, 'sandbox');
+    fs.mkdirSync(sandbox);
+    // The target deliberately does not exist: fs.symlinkSync happily plants
+    // the broken link, and realpathSync ENOENTs on it like a missing file.
+    fs.symlinkSync(
+      path.join('..', 'nonexistent-outside-target'),
+      path.join(sandbox, 'out.html')
+    );
+
+    expect(() => resolveWithin(sandbox, 'out.html')).toThrow(/dangling symlink/);
+
+    // The fix must not over-block lazy first writes, including in dirs that
+    // do not exist yet.
+    expect(resolveWithin(sandbox, 'sub', 'new.html')).toBe(
+      path.join(sandbox, 'sub', 'new.html')
+    );
+  });
+
+  it('a guarded write attempt through the dangling link creates nothing outside the root', async () => {
+    const area = makeTmpRoot();
+    const sandbox = path.join(area, 'sandbox');
+    fs.mkdirSync(sandbox);
+    const outsideTarget = path.join(area, 'nonexistent-outside-target');
+    fs.symlinkSync(
+      path.join('..', 'nonexistent-outside-target'),
+      path.join(sandbox, 'out.html')
+    );
+
+    // Pre-fix, the lexical fallback handed back the link path itself and
+    // writeFile materialized <area>/nonexistent-outside-target. The async
+    // wrapper turns the guard's synchronous throw into an awaitable rejection.
+    const guardedWrite = async () => {
+      await fs.promises.writeFile(resolveWithin(sandbox, 'out.html'), 'pwned');
+    };
+    await expect(guardedWrite()).rejects.toThrow(/dangling symlink/);
+
+    expect(fs.existsSync(outsideTarget)).toBe(false);
+    // The write never went through: the plant is still the original link.
+    expect(fs.lstatSync(path.join(sandbox, 'out.html')).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('MP-SEC-02 end-to-end: store writes stay inside the mocked home', () => {
+  it('writeArtifact rejects a traversal chatId and leaves nothing outside the root', async () => {
+    const home = fixtureHome.home as string;
+    const result = await writeArtifact('../evil', 'x.txt', 'pwned');
+
+    expect(result.success).toBe(false);
+    // Pre-fix vulnerable resolution would have been <home>/.everfern/evil/x.txt
+    expect(fs.existsSync(path.join(home, '.everfern', 'evil'))).toBe(false);
+    expect(fs.existsSync(path.join(home, '.everfern', 'evil', 'x.txt'))).toBe(false);
+  });
+
+  it('writeArtifact rejects a traversal filename and writes no escaped file', async () => {
+    const home = fixtureHome.home as string;
+    const result = await writeArtifact('chat1', '../../escaped.txt', 'pwned');
+
+    expect(result.success).toBe(false);
+    // Pre-fix vulnerable resolution would have been <home>/.everfern/escaped.txt
+    expect(fs.existsSync(path.join(home, '.everfern', 'escaped.txt'))).toBe(false);
+  });
+
+  it('writeArtifact rejects a planted dangling link and leaves the escaped target absent', async () => {
+    const home = fixtureHome.home as string;
+    // Materialize <home>/.everfern/artifacts/chat1 first so the dangling link
+    // can be planted inside the real artifacts dir of the fixture home.
+    await writeArtifact('chat1', 'seed.txt', 'x');
+
+    const outsideTarget = path.join(home, 'escaped-dangling-target');
+    // Relative link climbing three levels: chat1 -> artifacts -> .everfern ->
+    // <home>, so a followed write would land at <home>/escaped-dangling-target.
+    fs.symlinkSync(
+      path.join('..', '..', '..', 'escaped-dangling-target'),
+      path.join(home, '.everfern', 'artifacts', 'chat1', 'out.html')
+    );
+
+    const result = await writeArtifact('chat1', 'out.html', 'pwned');
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toMatch(/dangling symlink/);
+    // Nothing may exist at the link target — pre-fix this exact sequence
+    // created the file there.
+    expect(fs.existsSync(outsideTarget)).toBe(false);
+  });
+
+  it('writeSiteFile happy path still succeeds under the sandboxed home', async () => {
+    const home = fixtureHome.home as string;
+    const result = await writeSiteFile('goodsite', 'index.html', '<html></html>');
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(home, '.everfern', 'sites', 'goodsite', 'index.html'))).toBe(
+      true
+    );
+  });
+
+  it('deleteSite removes a site directory through the guarded path', async () => {
+    const home = fixtureHome.home as string;
+    await writeSiteFile('todelete', 'index.html', '<html></html>');
+    expect(fs.existsSync(path.join(home, '.everfern', 'sites', 'todelete'))).toBe(true);
+
+    const result = await deleteSite('todelete');
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(home, '.everfern', 'sites', 'todelete'))).toBe(false);
+  });
+});

--- a/main/__tests__/projects-path.test.ts
+++ b/main/__tests__/projects-path.test.ts
@@ -1,0 +1,196 @@
+/**
+ * MP-SEC-03 — projects:readFile / projects:readFileDataUrl path containment.
+ *
+ * Exercises the real handler implementations (via the exported
+ * registerProjectsHandlers surface) against real temp dirs:
+ * - renderer-supplied paths that escape the project root are rejected
+ * - symlinked project dirs still resolve to their real location
+ * - happy-path reads are unchanged (utf-8 text / base64 data URLs)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+vi.mock('../store/projects/projects', () => ({
+  projectsStore: {},
+}));
+
+import { registerProjectsHandlers } from '../ipc/projects';
+import { ipcMain } from 'electron';
+
+type Handler = (...args: any[]) => any;
+
+const handleMock = vi.mocked(ipcMain.handle) as unknown as ReturnType<typeof vi.fn>;
+
+function getHandler(channel: string): Handler {
+  const call = handleMock.mock.calls.find((c: any[]) => c[0] === channel);
+  if (!call) throw new Error(`handler not registered: ${channel}`);
+  return call[1] as Handler;
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'everfern-path-guard-'));
+const cleanups: string[] = [];
+
+function makeProject(): { projectPath: string; secretFile: string } {
+  const dir = fs.mkdtempSync(path.join(tmpRoot, 'project-'));
+  cleanups.push(dir);
+  const secretDir = fs.mkdtempSync(path.join(tmpRoot, 'secret-'));
+  cleanups.push(secretDir);
+  const secretFile = path.join(secretDir, 'outside.txt');
+  fs.writeFileSync(secretFile, 'TOP SECRET');
+  return { projectPath: dir, secretFile };
+}
+
+let readFile: Handler;
+let readFileDataUrl: Handler;
+
+beforeEach(() => {
+  handleMock.mockClear();
+  registerProjectsHandlers();
+  readFile = getHandler('projects:readFile');
+  readFileDataUrl = getHandler('projects:readFileDataUrl');
+});
+
+afterAll(() => {
+  for (const dir of [...cleanups, tmpRoot]) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+describe('projects:readFile containment', () => {
+  it('reads files inside the project (happy path preserved)', async () => {
+    const { projectPath } = makeProject();
+    fs.writeFileSync(path.join(projectPath, 'notes.txt'), 'hello everfern');
+    await expect(readFile(null, projectPath, 'notes.txt')).resolves.toBe('hello everfern');
+  });
+
+  it('reads files in nested subdirectories of the project', async () => {
+    const { projectPath } = makeProject();
+    fs.mkdirSync(path.join(projectPath, 'sub'));
+    fs.writeFileSync(path.join(projectPath, 'sub', 'a.txt'), 'nested');
+    await expect(readFile(null, projectPath, path.join('sub', 'a.txt'))).resolves.toBe('nested');
+  });
+
+  it('rejects simple ../ traversal out of the project', async () => {
+    const { projectPath, secretFile } = makeProject();
+    const rel = path.relative(projectPath, secretFile);
+    await expect(readFile(null, projectPath, rel)).resolves.toBeNull();
+  });
+
+  it('rejects deep ../ traversal that re-enters the tree lexically but lands outside', async () => {
+    const { projectPath, secretFile } = makeProject();
+    fs.mkdirSync(path.join(projectPath, 'sub'));
+    const rel = path.join('sub', '..', '..', path.basename(path.dirname(secretFile)), 'outside.txt');
+    await expect(readFile(null, projectPath, rel)).resolves.toBeNull();
+  });
+
+  it('rejects absolute paths outside the project', async () => {
+    const { projectPath, secretFile } = makeProject();
+    await expect(readFile(null, projectPath, secretFile)).resolves.toBeNull();
+  });
+
+  it('rejects the empty/identity path that resolves to the directory itself', async () => {
+    const { projectPath } = makeProject();
+    // resolves to the root dir → readFileSync EISDIR → null (same as before the fix)
+    await expect(readFile(null, projectPath, '.')).resolves.toBeNull();
+  });
+
+  it('returns null when the project dir does not exist (realpath throws)', async () => {
+    await expect(readFile(null, '/nonexistent/project/dir', 'x.txt')).resolves.toBeNull();
+  });
+
+  it('resolves symlinked project dirs via realpath and still contains paths', async () => {
+    const { projectPath, secretFile } = makeProject();
+    const linkPath = path.join(tmpRoot, `link-${path.basename(projectPath)}`);
+    try {
+      fs.symlinkSync(projectPath, linkPath);
+      cleanups.push(linkPath);
+      fs.writeFileSync(path.join(projectPath, 'inside.txt'), 'via symlink');
+      await expect(readFile(null, linkPath, 'inside.txt')).resolves.toBe('via symlink');
+      await expect(readFile(null, linkPath, secretFile)).resolves.toBeNull();
+    } finally {
+      try { fs.unlinkSync(linkPath); } catch { /* already cleaned */ }
+    }
+  });
+
+  it('rejects a symlink FILE inside the project whose target is outside', async () => {
+    const { projectPath, secretFile } = makeProject();
+    // notes.txt -> <outside secret>: lexical resolution stays contained, but the
+    // physical read would leak the target. Must return null, never the content.
+    fs.symlinkSync(secretFile, path.join(projectPath, 'notes.txt'));
+    await expect(readFile(null, projectPath, 'notes.txt')).resolves.toBeNull();
+  });
+
+  it('blocks reads of /etc/passwd through a planted symlink (no content leak)', async () => {
+    const { projectPath } = makeProject();
+    fs.symlinkSync('/etc/passwd', path.join(projectPath, 'passwd-link.txt'));
+    const res = await readFile(null, projectPath, 'passwd-link.txt');
+    expect(res).toBeNull();
+    expect(String(res)).not.toContain('root:');
+    expect(fs.readFileSync('/etc/passwd', 'utf-8').length).toBeGreaterThan(0); // sanity: readable outside
+  });
+});
+
+describe('projects:readFileDataUrl containment', () => {
+  it('builds a base64 data URL for files inside the project (happy path preserved)', async () => {
+    const { projectPath } = makeProject();
+    fs.writeFileSync(path.join(projectPath, 'img.bin'), Buffer.from([0xff, 0xd8, 0xff]));
+    const res = await readFileDataUrl(null, projectPath, 'img.bin');
+    expect(res.success).toBe(true);
+    expect(res.mimeType).toBe('application/octet-stream');
+    expect(res.size).toBe(3);
+    expect(res.dataUrl).toBe(`data:application/octet-stream;base64,${Buffer.from([0xff, 0xd8, 0xff]).toString('base64')}`);
+  });
+
+  it('rejects traversal escapes with the standard error shape', async () => {
+    const { projectPath, secretFile } = makeProject();
+    const res = await readFileDataUrl(null, projectPath, path.relative(projectPath, secretFile));
+    expect(res).toEqual({ success: false, error: expect.any(String) });
+    expect((res as any).dataUrl).toBeUndefined();
+  });
+
+  it('rejects absolute paths outside the project', async () => {
+    const { projectPath, secretFile } = makeProject();
+    const res = await readFileDataUrl(null, projectPath, secretFile);
+    expect(res.success).toBe(false);
+  });
+
+  it('returns error shape when project dir does not exist', async () => {
+    const res = await readFileDataUrl(null, '/nonexistent/project/dir', 'x.png');
+    expect(res.success).toBe(false);
+    expect(typeof res.error).toBe('string');
+  });
+
+  it('symlinked project dir works for inside files, blocks escapes', async () => {
+    const { projectPath, secretFile } = makeProject();
+    const linkPath = path.join(tmpRoot, `link-b64-${path.basename(projectPath)}`);
+    try {
+      fs.symlinkSync(projectPath, linkPath);
+      fs.writeFileSync(path.join(projectPath, 'ok.png'), Buffer.from([0x89, 0x50]));
+      const okRes = await readFileDataUrl(null, linkPath, 'ok.png');
+      expect(okRes.success).toBe(true);
+      expect(okRes.mimeType).toBe('image/png');
+      const badRes = await readFileDataUrl(null, linkPath, secretFile);
+      expect(badRes.success).toBe(false);
+    } finally {
+      try { fs.unlinkSync(linkPath); } catch { /* already cleaned */ }
+    }
+  });
+
+  it('returns the standard error shape for a symlink FILE escaping via /etc/passwd', async () => {
+    const { projectPath } = makeProject();
+    fs.symlinkSync('/etc/passwd', path.join(projectPath, 'leak.png'));
+    const res = await readFileDataUrl(null, projectPath, 'leak.png');
+    expect(res).toEqual({ success: false, error: 'Invalid file path' });
+    expect((res as any).dataUrl).toBeUndefined(); // no base64 of /etc content
+  });
+});

--- a/main/__tests__/tool-approvals-guard.test.ts
+++ b/main/__tests__/tool-approvals-guard.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Guard tests for main/store/tool-approvals — pins two fixes in place:
+ *
+ * MP-SEC-08 (quote-aware safe-prefix screen): isApproved() may only
+ * auto-approve a cmdTool command under the built-in safe prefixes when the
+ * WHOLE command is free of unquoted shell metacharacters (; & | ` $ ( ) < >
+ * redirection writes, and newline/CR). Inside double quotes, ` and $ still
+ * disqualify because bash performs substitution there; single quotes are
+ * fully literal (quoted > < are plain characters). Prefix matching is also
+ * exact-token at the head, so 'ls' cannot approve 'lsassdump'.
+ *
+ * MP-CORR-22 (session-scoped policies never persisted): addPolicy() keeps
+ * conversationId-bearing policies memory-only, and updatePolicy()'s save()
+ * filters them out of the on-disk JSON so a reload can never resurrect a
+ * session approval as a global one.
+ *
+ * Every store instance is constructed with a unique temp filePath under
+ * os.tmpdir() so ~/.everfern is never touched (importing the module itself is
+ * harmless — the exported singleton only reads on construction).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ToolApprovalStore } from '../store/tool-approvals';
+
+let tmpDir = '';
+let filePath = '';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ta-guard-'));
+  filePath = path.join(tmpDir, 'tool-approvals.json');
+});
+
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+describe('MP-SEC-08 quote-aware safe-prefix screen', () => {
+  function approvedWithEmptyStore(command: string): boolean {
+    const store = new ToolApprovalStore(filePath);
+    return store.isApproved('terminal_execute', { command });
+  }
+
+  it("rejects 'ls; rm -rf ~' despite matching the 'ls' safe prefix", () => {
+    expect(approvedWithEmptyStore('ls; rm -rf ~')).toBe(false);
+  });
+
+  it("approves plain 'ls'", () => {
+    expect(approvedWithEmptyStore('ls')).toBe(true);
+  });
+
+  it("approves 'ls -la'", () => {
+    expect(approvedWithEmptyStore('ls -la')).toBe(true);
+  });
+
+  it("approves 'echo \"a;b\"' — semicolon inside double quotes is not chaining", () => {
+    expect(approvedWithEmptyStore('echo "a;b"')).toBe(true);
+  });
+
+  it("approves \"echo 'a;b'\" — single quotes are fully literal", () => {
+    expect(approvedWithEmptyStore("echo 'a;b'")).toBe(true);
+  });
+
+  it("rejects 'dir & format c:'", () => {
+    expect(approvedWithEmptyStore('dir & format c:')).toBe(false);
+  });
+
+  it("rejects 'ls | wc -l'", () => {
+    expect(approvedWithEmptyStore('ls | wc -l')).toBe(false);
+  });
+
+  it("rejects 'ls $(whoami)' — unquoted $ substitution", () => {
+    expect(approvedWithEmptyStore('ls $(whoami)')).toBe(false);
+  });
+
+  it("rejects 'ls `id`' — unquoted backtick substitution", () => {
+    expect(approvedWithEmptyStore('ls `id`')).toBe(false);
+  });
+
+  it("rejects 'git status&&rm x'", () => {
+    expect(approvedWithEmptyStore('git status&&rm x')).toBe(false);
+  });
+
+  it("rejects a real newline: 'ls\\nrm -rf ~'", () => {
+    expect(approvedWithEmptyStore('ls\nrm -rf ~')).toBe(false);
+  });
+
+  it("rejects 'echo \"hi$(id)\"' — substitution inside double quotes fails closed", () => {
+    expect(approvedWithEmptyStore('echo "hi$(id)"')).toBe(false);
+  });
+
+  it("rejects 'echo x > ~/evil' — unquoted > redirection write", () => {
+    expect(approvedWithEmptyStore('echo x > ~/evil')).toBe(false);
+  });
+
+  it("rejects 'ls >> log' — unquoted >> append", () => {
+    expect(approvedWithEmptyStore('ls >> log')).toBe(false);
+  });
+
+  it("rejects 'git status > p.ps1' — unquoted > redirection write", () => {
+    expect(approvedWithEmptyStore('git status > p.ps1')).toBe(false);
+  });
+
+  it("rejects 'cat < /etc/passwd' — unquoted < redirection (cat is not even a safe prefix)", () => {
+    expect(approvedWithEmptyStore('cat < /etc/passwd')).toBe(false);
+  });
+
+  it("rejects a real carriage return: 'ls\\rrm -rf ~'", () => {
+    expect(approvedWithEmptyStore('ls\rrm -rf ~')).toBe(false);
+  });
+
+  it("rejects 'lsassdump' — prefix match is exact-token at the head", () => {
+    expect(approvedWithEmptyStore('lsassdump')).toBe(false);
+  });
+
+  it("rejects 'lsof -i' — not a safe prefix despite sharing the 'ls' head", () => {
+    expect(approvedWithEmptyStore('lsof -i')).toBe(false);
+  });
+
+  it("approves 'dir /b'", () => {
+    expect(approvedWithEmptyStore('dir /b')).toBe(true);
+  });
+
+  it("approves 'node -v'", () => {
+    expect(approvedWithEmptyStore('node -v')).toBe(true);
+  });
+
+  it("approves 'echo \"a>b\"' — quoted > is a literal character, not redirection", () => {
+    expect(approvedWithEmptyStore('echo "a>b"')).toBe(true);
+  });
+
+  it("approves \"echo 'x>y'\" — single quotes are fully literal", () => {
+    expect(approvedWithEmptyStore("echo 'x>y'")).toBe(true);
+  });
+
+  it("rejects 'echo hi > out.txt' — unquoted > outside the quoted span", () => {
+    expect(approvedWithEmptyStore('echo hi > out.txt')).toBe(false);
+  });
+});
+
+describe('MP-CORR-22 scoped-policy persistence', () => {
+  it('updatePolicy/save persists only global policies; session-scoped ones stay memory-only', () => {
+    const store1 = new ToolApprovalStore(filePath);
+    const globalP = store1.addPolicy({ type: 'prefix', toolName: 'bash', pattern: 'git push' });
+    const scopedP = store1.addPolicy({
+      type: 'prefix',
+      toolName: 'bash',
+      pattern: 'npm test',
+      conversationId: 'conv-A',
+    });
+    expect(globalP.conversationId).toBeUndefined();
+    expect(scopedP.conversationId).toBe('conv-A');
+
+    store1.updatePolicy(globalP.id, { pattern: 'git pull' });
+    // Scoped update still triggers save() — the filter must drop it on write.
+    store1.updatePolicy(scopedP.id, { pattern: 'npm run test:all' });
+
+    const store2 = new ToolApprovalStore(filePath); // reload straight from disk
+    const reloaded = store2.getPolicies();
+
+    expect(reloaded.filter((p) => p.conversationId !== undefined)).toHaveLength(0);
+    expect(reloaded).toHaveLength(1);
+    expect(reloaded[0].pattern).toBe('git pull');
+
+    expect(store2.getPolicies().some((p) => p.pattern === 'npm run test:all')).toBe(false);
+  }, 5000);
+
+  it('on-disk JSON contains exactly one entry and no conversationId key anywhere', () => {
+    const store1 = new ToolApprovalStore(filePath);
+    store1.addPolicy({ type: 'prefix', toolName: 'bash', pattern: 'git push' });
+    const scopedP = store1.addPolicy({
+      type: 'prefix',
+      toolName: 'bash',
+      pattern: 'npm test',
+      conversationId: 'conv-A',
+    });
+    store1.updatePolicy(scopedP.id, { pattern: 'npm run test:all' });
+
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed).toHaveLength(1);
+    expect(raw.includes('conversationId')).toBe(false);
+  }, 5000);
+});
+
+describe('MP-CORR-22 regression sanity', () => {
+  it("approves 'git pull origin main' via the persisted policy, not the built-in prefix list", () => {
+    const store1 = new ToolApprovalStore(filePath);
+    const globalP = store1.addPolicy({ type: 'prefix', toolName: 'bash', pattern: 'git push' });
+    const scopedP = store1.addPolicy({
+      type: 'prefix',
+      toolName: 'bash',
+      pattern: 'npm test',
+      conversationId: 'conv-A',
+    });
+    store1.updatePolicy(globalP.id, { pattern: 'git pull' });
+    store1.updatePolicy(scopedP.id, { pattern: 'npm run test:all' });
+
+    const store2 = new ToolApprovalStore(filePath);
+    // 'git pull' is not in safePrefixes, so this approval can only come from
+    // the persisted explicit policy.
+    expect(store2.isApproved('bash', { command: 'git pull origin main' })).toBe(true);
+  }, 5000);
+
+  it('a fresh empty store does not auto-approve beyond the built-in safe list', () => {
+    const bare = new ToolApprovalStore(path.join(tmpDir, 'bare-tool-approvals.json'));
+    expect(bare.getPolicies()).toHaveLength(0);
+    expect(bare.isApproved('bash', { command: 'npm run test:all' })).toBe(false);
+    expect(bare.isApproved('bash', { command: 'git pull origin main' })).toBe(false);
+  }, 5000);
+});

--- a/main/__tests__/wave3-fixes.test.ts
+++ b/main/__tests__/wave3-fixes.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Wave 3 fixes — normalizeLocalUrl + scheduler calculateNextRun termination contract.
+ *
+ * calculateNextRun regressions locked here:
+ * - 'every N week' units were silently unsupported (cold start degraded to +1 day,
+ *   and with a lastRun the past timestamp itself was returned, re-triggering the
+ *   task on every 60s scheduler tick).
+ * - malformed expressions like 'every banana' threw TypeError on unit.startsWith.
+ * All interval cases must terminate in finite time (no main-process hangs).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Cut heavy transitive chains (sqlite/db, agent runner graph) — calculateNextRun
+// and the exported singleton never touch these in the paths under test.
+vi.mock('../store/scheduled-tasks', () => ({
+  scheduledTasksStore: {
+    list: vi.fn(async () => []),
+    save: vi.fn(async () => undefined),
+    updateRunTimes: vi.fn(async () => undefined),
+  },
+}));
+vi.mock('../agent/runner/runner', () => ({ AgentRunner: class {} }));
+vi.mock('../store/history', () => ({ ChatHistoryStore: class {} }));
+
+import { SchedulerService } from '../integrations/scheduler-service';
+import { normalizeLocalUrl } from '../lib/ai-client';
+
+describe('normalizeLocalUrl', () => {
+  it('rewrites http localhost preserving port and path', () => {
+    expect(normalizeLocalUrl('http://localhost:11434')).toBe('http://127.0.0.1:11434');
+    expect(normalizeLocalUrl('http://localhost')).toBe('http://127.0.0.1');
+    expect(normalizeLocalUrl('http://localhost:8080/api/tags?x=1')).toBe(
+      'http://127.0.0.1:8080/api/tags?x=1'
+    );
+  });
+
+  it('rewrites bracketed IPv6 loopback (::1) preserving port and path', () => {
+    expect(normalizeLocalUrl('http://[::1]:11434')).toBe('http://127.0.0.1:11434');
+    expect(normalizeLocalUrl('http://[::1]/v1/chat')).toBe('http://127.0.0.1/v1/chat');
+  });
+
+  it('leaves https URLs alone (local inference endpoints are plain http)', () => {
+    expect(normalizeLocalUrl('https://localhost:11434')).toBe('https://localhost:11434');
+    expect(normalizeLocalUrl('https://[::1]:8080')).toBe('https://[::1]:8080');
+  });
+
+  it('passes through undefined and non-local URLs untouched', () => {
+    expect(normalizeLocalUrl(undefined)).toBeUndefined();
+    expect(normalizeLocalUrl('http://192.168.1.5:11434')).toBe('http://192.168.1.5:11434');
+    expect(normalizeLocalUrl('http://example.com')).toBe('http://example.com');
+  });
+});
+
+describe('SchedulerService.calculateNextRun', () => {
+  const NOW = new Date('2026-08-25T10:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("'every 5 minutes' cold start advances exactly one interval, finite time", () => {
+    const next = SchedulerService.calculateNextRun('every 5 minutes');
+    expect(next.getTime()).toBe(NOW.getTime() + 5 * 60_000);
+    expect(next.getTime()).toBeGreaterThan(NOW.getTime());
+    expect(Number.isNaN(next.getTime())).toBe(false);
+  }, 2000);
+
+  it("'every 1 week' terminates and lands exactly 7 days out (infinite-loop regression)", () => {
+    const next = SchedulerService.calculateNextRun('every 1 week');
+    expect(next.getTime()).toBe(NOW.getTime() + 7 * 24 * 60 * 60_000);
+  }, 2000);
+
+  it("'every 1 week' with lastRun steps forward instead of returning the past", () => {
+    const last = new Date(NOW.getTime() - 3 * 24 * 60 * 60_000);
+    const next = SchedulerService.calculateNextRun('every 1 week', last);
+    expect(next.getTime()).toBe(last.getTime() + 7 * 24 * 60 * 60_000);
+    expect(next.getTime()).toBeGreaterThan(NOW.getTime());
+  }, 2000);
+
+  it("'every banana' terminates via the default daily step with a valid Date", () => {
+    const next = SchedulerService.calculateNextRun('every banana');
+    expect(Number.isNaN(next.getTime())).toBe(false);
+    expect(next.getTime()).toBe(NOW.getTime() + 24 * 60 * 60_000);
+  }, 2000);
+
+  it("non-positive values ('every 0 minutes', negative hours) terminate with a future date", () => {
+    const zero = SchedulerService.calculateNextRun('every 0 minutes');
+    expect(Number.isNaN(zero.getTime())).toBe(false);
+    expect(zero.getTime()).toBeGreaterThan(NOW.getTime());
+
+    const neg = SchedulerService.calculateNextRun('every -3 hours');
+    expect(Number.isNaN(neg.getTime())).toBe(false);
+    expect(neg.getTime()).toBeGreaterThan(NOW.getTime());
+  }, 2000);
+
+  it("existing 'daily' behavior is unregressed", () => {
+    // Daily keeps the same wall-clock time one calendar day out.
+    // Aug 25->26 crosses no DST in common TZs, so the epoch delta is exactly 24h.
+    const next = SchedulerService.calculateNextRun('daily');
+    expect(next.getTime()).toBe(NOW.getTime() + 86_400_000);
+  });
+});

--- a/main/agent/prompts/NAVIS.md
+++ b/main/agent/prompts/NAVIS.md
@@ -1,3 +1,4 @@
+SYSTEM_PROMPT = """
 <role>
 You are Navis — an advanced AI browser automation agent. You have full control of a Chromium browser through a Chrome extension using CDP (Chrome DevTools Protocol).
 You can browse the web, search for content, interact with pages, and complete end-to-end tasks.

--- a/main/agent/runner/services/agent-runtime.ts
+++ b/main/agent/runner/services/agent-runtime.ts
@@ -444,8 +444,10 @@ export async function runAgentStep(
         normalizedMessages.unshift(systemMsg);
       }
       
-      systemMsg.content += `\n\n# PERSONALITY & BEHAVIOR CORE (SOUL.md)\n${soulContent}\n`;
-      console.log(`[AgentRuntime] 🎭 Injected SOUL.md personality into ${nodeName} step`);
+      if (typeof systemMsg.content === 'string' && !systemMsg.content.includes('# PERSONALITY & BEHAVIOR CORE')) {
+        systemMsg.content += `\n\n# PERSONALITY & BEHAVIOR CORE (SOUL.md)\n${soulContent}\n`;
+        console.log(`[AgentRuntime] 🎭 Injected SOUL.md personality into ${nodeName} step`);
+      }
     } catch (soulErr) {
       console.warn('[AgentRuntime] Failed to inject SOUL.md:', soulErr);
     }

--- a/main/agent/tools/create-artifact.ts
+++ b/main/agent/tools/create-artifact.ts
@@ -171,8 +171,8 @@ export const createArtifactTool = (runner?: any): AgentTool => ({
           if (isDockerInternal) {
             try {
               onUpdate?.(`📖 Reading Docker file: ${filePathParam}...`);
-              const { execSync } = require('child_process');
-              content = execSync(`docker exec everfern-ubuntu cat "${filePathParam}"`, { encoding: 'utf-8', timeout: 30000 });
+              const { execFileSync } = require('child_process');
+              content = execFileSync('docker', ['exec', 'everfern-ubuntu', 'cat', filePathParam], { encoding: 'utf8', timeout: 30000, maxBuffer: 10 * 1024 * 1024 });
               fileRead = true;
             } catch (err) {
               console.warn(`[CreateArtifact] Failed to read Docker file:`, err);

--- a/main/agent/tools/dev-server-manager.ts
+++ b/main/agent/tools/dev-server-manager.ts
@@ -35,10 +35,10 @@ const runningServers = new Map<string, ServerProcess>();
 async function detectFramework(projectRoot: string): Promise<string> {
   try {
     const packageJsonPath = path.join(projectRoot, 'package.json');
-    const { execSync } = require('child_process');
+    const fs = require('fs');
 
     // Try to detect framework from common dependencies
-    const result = execSync(`cat "${packageJsonPath}"`, { encoding: 'utf8' });
+    const result = fs.readFileSync(packageJsonPath, 'utf8');
     const packageJson = JSON.parse(result);
     const deps = { ...packageJson.dependencies, ...packageJson.devDependencies };
 

--- a/main/agent/tools/linux-vm-executor.ts
+++ b/main/agent/tools/linux-vm-executor.ts
@@ -15,6 +15,25 @@ export interface LinuxVMExecutionResult {
 }
 
 /**
+ * Commands considered read-only by their first token. When the Linux VM
+ * (WSL/Docker) is unavailable, ONLY these may fall back to native host
+ * execution; anything else must never silently run on the host.
+ *
+ * DRIFT GUARD: pi-tools.ts keeps a local mirror of this set (READ_ONLY_HEADS,
+ * above its executePwsh adapter) because test suites may mock this module —
+ * any change here MUST be mirrored there and vice versa. This file's copy is
+ * the exported reference.
+ */
+export const READ_ONLY_HEADS: ReadonlySet<string> = new Set([
+  'dir', 'type', 'cat', 'ls', 'pwd', 'whoami', 'hostname', 'which',
+  'head', 'tail', 'wc', 'find', 'grep', 'echo', 'uname', 'df'
+]);
+
+function getCommandHead(command: string): string {
+  return command.trim().toLowerCase().split(/\s+/)[0];
+}
+
+/**
  * Thin wrapper that runs any shell command in a Linux VM environment.
  *
  * Platform-specific implementations:
@@ -60,7 +79,15 @@ export async function runInLinuxVM(
         return await runNatively(command, cwd, onUpdate);
     }
   } catch (error) {
-    console.warn(`[runInLinuxVM] VM execution failed, falling back to native execution: ${error}`);
+    if (!READ_ONLY_HEADS.has(getCommandHead(command))) {
+      console.warn(`[VMExecutor] VM unavailable — blocking host fallback for non-read-only command "${getCommandHead(command)}": ${error}`);
+      return {
+        stdout: '',
+        stderr: `Linux VM (WSL/Docker) is not available. Start WSL/Docker or re-run with target main. (Original error: ${error})`,
+        exitCode: -1
+      };
+    }
+    console.log('[VMExecutor] VM unavailable — read-only fallback on host');
     return await runNatively(command, cwd, onUpdate);
   }
 }

--- a/main/agent/tools/navis/agent/extension-orchestrator.ts
+++ b/main/agent/tools/navis/agent/extension-orchestrator.ts
@@ -56,7 +56,7 @@ function wrapUntrusted(nonce: string, label: string, content: string): string {
 function loadExtensionPrompt(): string {
   const rawPrompt = loadPrompt('NAVIS.md');
   if (!rawPrompt) return FALLBACK_EXTENSION_SYSTEM_PROMPT + SECURITY_GUIDELINE;
-  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\?\s*([\s\S]*?)"""/);
+  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\s*([\s\S]*?)"""/);
   if (!systemMatch) return FALLBACK_EXTENSION_SYSTEM_PROMPT + SECURITY_GUIDELINE;
   let systemPrompt = systemMatch[1].trim();
   systemPrompt += SECURITY_GUIDELINE;

--- a/main/agent/tools/navis/agent/orchestrator.ts
+++ b/main/agent/tools/navis/agent/orchestrator.ts
@@ -58,11 +58,11 @@ function wrapUntrusted(nonce: string, label: string, content: string): string {
 function loadNavisPrompts(): { systemPrompt: string; nextStepPrompt: string } {
   const rawPrompt = loadPrompt('NAVIS.md');
   if (!rawPrompt) return { systemPrompt: FALLBACK_SYSTEM_PROMPT + SECURITY_GUIDELINE, nextStepPrompt: '' };
-  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\?\s*([\s\S]*?)"""/);
+  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\s*([\s\S]*?)"""/);
   if (!systemMatch) return { systemPrompt: FALLBACK_SYSTEM_PROMPT + SECURITY_GUIDELINE, nextStepPrompt: '' };
   let systemPrompt = systemMatch[1].trim();
   systemPrompt += SECURITY_GUIDELINE;
-  const nextStepMatch = rawPrompt.match(/NEXT_STEP_PROMPT = """\?\s*([\s\S]*?)"""/);
+  const nextStepMatch = rawPrompt.match(/NEXT_STEP_PROMPT = """\s*([\s\S]*?)"""/);
   return { systemPrompt, nextStepPrompt: nextStepMatch ? nextStepMatch[1].trim() : '' };
 }
 

--- a/main/agent/tools/navis/agent/prompt-builder.ts
+++ b/main/agent/tools/navis/agent/prompt-builder.ts
@@ -30,7 +30,7 @@ function loadNavisPrompts(): { systemPrompt: string; nextStepPrompt: string } {
   const rawPrompt = loadPrompt('NAVIS.md');
   if (!rawPrompt) return { systemPrompt: FALLBACK_SYSTEM_PROMPT, nextStepPrompt: '' };
 
-  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\?\s*([\s\S]*?)"""/);
+  const systemMatch = rawPrompt.match(/SYSTEM_PROMPT = """\s*([\s\S]*?)"""/);
   if (!systemMatch) {
     console.warn('[Navis] Failed to parse SYSTEM_PROMPT from NAVIS.md. Using fallback.');
     return { systemPrompt: FALLBACK_SYSTEM_PROMPT, nextStepPrompt: '' };
@@ -38,7 +38,7 @@ function loadNavisPrompts(): { systemPrompt: string; nextStepPrompt: string } {
 
   let systemPrompt = systemMatch[1].trim() + SECURITY_GUIDELINE;
 
-  const nextStepMatch = rawPrompt.match(/NEXT_STEP_PROMPT = """\?\s*([\s\S]*?)"""/);
+  const nextStepMatch = rawPrompt.match(/NEXT_STEP_PROMPT = """\s*([\s\S]*?)"""/);
   const nextStepPrompt = nextStepMatch ? nextStepMatch[1].trim() : '';
 
   return { systemPrompt, nextStepPrompt };

--- a/main/agent/tools/pi-tools.ts
+++ b/main/agent/tools/pi-tools.ts
@@ -15,6 +15,7 @@ import { taskCompleteTool } from './task-complete';
 
 import * as os from 'os';
 import { runOcrPdf } from '../../ocr/ocr';
+import { hasUnquotedMetacharacters } from '../../store/tool-approvals';
 
 async function existsAsync(p: string): Promise<boolean> {
   try {
@@ -156,6 +157,14 @@ export function performSmartReplace(content: string, oldString: string, newStrin
 
 // File tool names that run on the host and need Linux→Windows path translation
 const HOST_FILE_TOOL_NAMES = new Set(['read', 'write', 'edit', 'grep', 'find', 'ls']);
+
+// Read-only command heads (mirrors READ_ONLY_HEADS in linux-vm-executor; kept
+// local because test suites vi.mock that module without this export). When the
+// VM is unavailable, only these may fall back to ungated native host execution.
+const READ_ONLY_HEADS = new Set([
+  'dir', 'type', 'cat', 'ls', 'pwd', 'whoami', 'hostname', 'which',
+  'head', 'tail', 'wc', 'find', 'grep', 'echo', 'uname', 'df'
+]);
 
 function previewValue(value: unknown, max = 140): string {
   if (typeof value === 'string') {
@@ -703,15 +712,19 @@ function adaptTool(
             };
           }
 
-          const isHostCommand = (cmd: string): boolean => {
-            const normalized = cmd.trim().toLowerCase();
-            if (normalized.includes('/mnt/') || normalized.includes('/home/') || normalized.includes('/tmp/') || /\bsource\b/.test(normalized)) {
-              return false;
-            }
-            return /^(npm|npx|yarn|node|git|powershell|pwsh|cmd|set-location)\b/i.test(normalized);
-          };
+          // Windows convenience: these READ-ONLY heads may auto-run locally without a prompt.
+          // Anything else (powershell/cmd/npm/git/...) requires the normal approval flow.
+          // 'systeminfo' deliberately excluded (slow, leaks host details) — it rides the
+          // normal approval flow instead.
+          const WIN_AUTO_LOCAL_HEADS = new Set(['dir', 'type', 'where', 'hostname', 'whoami']);
+          const headMatches = (cmd: string, heads: Set<string>): boolean => heads.has(cmd.trim().toLowerCase().split(/\s+/)[0]);
 
-          const runLocally = local || (process.platform === 'win32' && isHostCommand(command));
+          // MP-SEC-10 Fix: the head match alone is NOT sufficient. The FULL command must
+          // also pass tool-approvals' quote-aware metacharacter screen, otherwise tails
+          // like "dir; Remove-Item x" would ride an auto-local head unprompted.
+          const runLocally = local || (process.platform === 'win32'
+            && headMatches(command, WIN_AUTO_LOCAL_HEADS)
+            && !hasUnquotedMetacharacters(command || ''));
 
           if (runLocally) {
             if (local && !reason) {
@@ -880,6 +893,24 @@ function adaptTool(
               };
             }
           } catch (vmError: any) {
+            // Same read-only concept as linux-vm-executor's host fallback gate:
+            // a VM failure must never silently run non-read-only commands on
+            // the host — surface the VM-unavailable error to the model instead.
+            const vmFallbackHead = (command || '').trim().toLowerCase().split(/\s+/)[0];
+            if (!READ_ONLY_HEADS.has(vmFallbackHead)) {
+              console.warn(`[PiTools] VM unavailable — blocking native fallback for non-read-only command "${vmFallbackHead}": ${vmError?.message || vmError}`);
+              const vmUnavailableMsg = 'Linux VM (WSL/Docker) is not available. Start WSL/Docker or re-run with target main.';
+              return {
+                success: false,
+                output: stripAnsi(`${vmUnavailableMsg}\n(Original VM error: ${vmError?.message || vmError})`),
+                error: stripAnsi(`${vmUnavailableMsg} (Original VM error: ${vmError?.message || vmError})`),
+                data: {
+                  target: 'vm',
+                  exitCode: -1,
+                },
+              };
+            }
+
             console.warn('Linux VM execution failed, falling back to native:', vmError);
 
             const isMock = typeof (executor as any).mock === 'object' || (executor as any)._isMock || executor.name === 'mockConstructor';

--- a/main/agent/tools/present-files.ts
+++ b/main/agent/tools/present-files.ts
@@ -267,7 +267,7 @@ export const createPresentFilesTool = (runner?: any): AgentTool => ({
       if (!fileCopied && process.platform === 'darwin') {
         try {
           fs.mkdirSync(artifactsDir, { recursive: true });
-          const { execSync } = require('child_process');
+          const { execFileSync } = require('child_process');
           const dockerPaths = [
             f.path.startsWith('/') ? f.path : null,
             `/everfern/${fileName}`,
@@ -278,7 +278,7 @@ export const createPresentFilesTool = (runner?: any): AgentTool => ({
 
           for (const dp of dockerPaths) {
             try {
-              execSync(`docker cp everfern-ubuntu:"${dp}" "${targetPath}"`, { timeout: 15000, stdio: 'pipe' });
+              execFileSync('docker', ['cp', `everfern-ubuntu:${dp}`, targetPath], { timeout: 15000, stdio: 'pipe', maxBuffer: 10 * 1024 * 1024 });
               if (fs.existsSync(targetPath)) {
                 fileCopied = true;
                 console.log(`[PresentFiles] Copied Docker file ${dp} to host artifacts at ${targetPath}`);

--- a/main/computer-overlay.ts
+++ b/main/computer-overlay.ts
@@ -20,6 +20,7 @@ export class ComputerOverlayManager {
   // Physical pixel dimensions of the primary display (robotjs coordinate space)
   private physicalWidth = 1920;
   private physicalHeight = 1080;
+  private hideTimeout: NodeJS.Timeout | null = null;
 
   constructor() {
     console.log('[ComputerOverlay] Manager created, preloading window at startup...');
@@ -93,6 +94,10 @@ export class ComputerOverlayManager {
    * Show the overlay and begin a computer_use session.
    */
   show(taskDescription?: string): void {
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
     this.ensureWindow();
     if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
 
@@ -122,8 +127,9 @@ export class ComputerOverlayManager {
       active: false,
     });
 
-    setTimeout(() => {
-      if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
+    this.hideTimeout = setTimeout(() => {
+      this.hideTimeout = null;
+      if (!this.isActive && this.overlayWindow && !this.overlayWindow.isDestroyed()) {
         this.overlayWindow.hide();
       }
     }, 400);
@@ -176,6 +182,10 @@ export class ComputerOverlayManager {
    * Clean up resources.
    */
   destroy(): void {
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
     if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
       this.overlayWindow.close();
     }

--- a/main/integrations/message-handler.ts
+++ b/main/integrations/message-handler.ts
@@ -414,6 +414,7 @@ export class MessageHandler extends EventEmitter {
         // Requirement 6.4: Generic agent runner failure
         console.error(`[MessageHandler] ❌ Generic error: ${errorMsg}`);
         const failureMessage = errorMsg.toLowerCase().includes('fetch failed') || errorMsg.toLowerCase().includes('network')
+          || errorMsg.includes('ECONNREFUSED') || errorMsg.includes('not reachable')
           ? 'I could not reach the configured AI provider. Please check the provider endpoint/API key, then try again.'
           : 'Failed to process your message. Please try again.';
         if (activeErrorMessage) {

--- a/main/integrations/scheduler-service.ts
+++ b/main/integrations/scheduler-service.ts
@@ -151,8 +151,20 @@ export class SchedulerService {
       }
     } else if (cron.startsWith('every ')) {
       const parts = cron.split(' ');
-      const value = parseInt(parts[1]);
-      const unit = parts[2];
+      const parsedValue = parseInt(parts[1]);
+      // Non-numeric interval (e.g. 'every five minutes') parses to NaN, which would make
+      // the initial step produce an Invalid Date whose comparisons are always false and
+      // even the loop's else-progress branch would never run. Fall back to 0 so the
+      // loop's default daily-step branch applies instead.
+      const value = Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : 0;
+      // Missing unit token ("every banana") would crash on unit.startsWith below —
+      // default to a daily step so we always return a valid, future date.
+      const unit = typeof parts[2] === 'string' ? parts[2].toLowerCase() : '';
+
+      if (!unit) {
+        next.setDate(next.getDate() + 1);
+        return next;
+      }
 
       if (unit.startsWith('minute')) {
         next.setMinutes(next.getMinutes() + value);
@@ -160,13 +172,21 @@ export class SchedulerService {
         next.setHours(next.getHours() + value);
       } else if (unit.startsWith('day')) {
         next.setDate(next.getDate() + value);
+      } else if (unit.startsWith('week')) {
+        next.setDate(next.getDate() + value * 7);
       }
 
       // Ensure we don't return a time in the past if no lastRun
+      let iterations = 0;
       while (!lastRun && next <= now) {
-        if (unit.startsWith('minute')) next.setMinutes(next.getMinutes() + value);
-        else if (unit.startsWith('hour')) next.setHours(next.getHours() + value);
-        else if (unit.startsWith('day')) next.setDate(next.getDate() + value);
+        const before = next.getTime();
+        if (value > 0 && unit.startsWith('minute')) next.setMinutes(next.getMinutes() + value);
+        else if (value > 0 && unit.startsWith('hour')) next.setHours(next.getHours() + value);
+        else if (value > 0 && unit.startsWith('day')) next.setDate(next.getDate() + value);
+        else if (value > 0 && unit.startsWith('week')) next.setDate(next.getDate() + value * 7);
+        else next.setDate(next.getDate() + 1); // Unknown/invalid unit: default daily step so we always progress.
+        // Cap exhaustion leaves next <= now, so shouldRun fires the overdue task once immediately (documented semantics).
+        if (++iterations > 10000 || next.getTime() === before) break; // Safety: never hang the main process.
       }
     } else {
       // Default fallback

--- a/main/ipc/agent/stream-handlers.ts
+++ b/main/ipc/agent/stream-handlers.ts
@@ -339,7 +339,7 @@ export function registerStreamHandlers(): void {
           } catch (e) {
             console.error('[AgentIPC] Failed to hide overlay:', e);
           }
-          streamSender.send('acp:stream-chunk', { delta: '\n\n🛑 Stopped by user.', done: true, conversationId: request.conversationId, assistantMessageId: request.assistantMessageId });
+          safeSend('acp:stream-chunk', { delta: '\n\n🛑 Stopped by user.', done: true, conversationId: request.conversationId, assistantMessageId: request.assistantMessageId });
           break;
         }
 
@@ -537,7 +537,7 @@ export function registerStreamHandlers(): void {
         console.error('[AgentIPC] Cleanup sequence error on stream crash:', cleanupErr);
       }
 
-      streamSender.send('acp:stream-chunk', { delta: `\n\n[Error: ${String(error)}]`, done: true, conversationId: request.conversationId, assistantMessageId: request.assistantMessageId });
+      safeSend('acp:stream-chunk', { delta: `\n\n[Error: ${String(error)}]`, done: true, conversationId: request.conversationId, assistantMessageId: request.assistantMessageId });
     }
   });
 }

--- a/main/ipc/history.ts
+++ b/main/ipc/history.ts
@@ -13,6 +13,8 @@ export function registerHistoryHandlers(historyStore: ChatHistoryStore) {
   });
 
   ipcMain.handle('history:save', async (_event, conv) => {
+    // Renderer channel omits isFullSave; absence means an explicit full-snapshot save.
+    if (conv && !('isFullSave' in conv)) conv.isFullSave = true;
     return await historyStore.save(conv);
   });
 

--- a/main/ipc/projects.ts
+++ b/main/ipc/projects.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import { projectsStore } from '../store/projects/projects';
+import { resolveWithin } from '../lib/path-guard';
 
 function mimeFromExt(ext: string): string {
   const clean = ext.replace(/^\./, '').toLowerCase();
@@ -123,9 +124,9 @@ export function registerProjectsHandlers() {
 
   ipcMain.handle('projects:readFile', async (_event, projectPath: string, filePath: string) => {
     const fs = require('fs');
-    const path = require('path');
-    const fullPath = path.join(projectPath, filePath);
     try {
+      const root = fs.realpathSync(projectPath);
+      const fullPath = resolveWithin(root, filePath);
       return fs.readFileSync(fullPath, 'utf-8');
     } catch {
       return null;
@@ -135,9 +136,15 @@ export function registerProjectsHandlers() {
   ipcMain.handle('projects:readFileDataUrl', async (_event, projectPath: string, filePath: string) => {
     const fs = require('fs');
     const path = require('path');
-    const fullPath = path.join(projectPath, filePath);
     const maxPreviewBytes = 32 * 1024 * 1024;
     try {
+      const root = fs.realpathSync(projectPath);
+      let fullPath: string;
+      try {
+        fullPath = resolveWithin(root, filePath);
+      } catch {
+        return { success: false, error: 'Invalid file path' };
+      }
       const stat = fs.statSync(fullPath);
       if (!stat.isFile()) return { success: false, error: 'Path is not a file' };
       if (stat.size > maxPreviewBytes) {

--- a/main/ipc/store-handlers.ts
+++ b/main/ipc/store-handlers.ts
@@ -3,22 +3,113 @@ import { listArtifacts, readArtifact, writeArtifact, deleteArtifact } from '../s
 import { listPlans, readPlan, writePlan, deletePlan } from '../store/plans';
 import { listSites, readSiteFile, writeSiteFile, deleteSite } from '../store/sites';
 
+// MP-SEC-02: store helpers throw on renderer-supplied identifiers/paths that
+// escape their sandbox roots; convert those rejections to each endpoint's
+// existing failure shape instead of leaking raw errors to the renderer.
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function registerStoreHandlers() {
   // Artifacts
-  ipcMain.handle('artifacts:list', async (_e, chatId?: string, projectPath?: string) => await listArtifacts(chatId, projectPath));
-  ipcMain.handle('artifacts:read', async (_e, chatId: string, filename: string, projectPath?: string) => await readArtifact(chatId, filename, projectPath));
-  ipcMain.handle('artifacts:write', async (_e, chatId: string, filename: string, content: string, projectPath?: string) => await writeArtifact(chatId, filename, content, projectPath));
-  ipcMain.handle('artifacts:delete', async (_e, chatId: string, filename: string, projectPath?: string) => await deleteArtifact(chatId, filename, projectPath));
+  ipcMain.handle('artifacts:list', async (_e, chatId?: string, projectPath?: string) => {
+    try {
+      return await listArtifacts(chatId, projectPath);
+    } catch (err) {
+      console.error('[StoreHandlers] artifacts:list rejected:', errMessage(err));
+      return [];
+    }
+  });
+  ipcMain.handle('artifacts:read', async (_e, chatId: string, filename: string, projectPath?: string) => {
+    try {
+      return await readArtifact(chatId, filename, projectPath);
+    } catch (err) {
+      console.error('[StoreHandlers] artifacts:read rejected:', errMessage(err));
+      return null;
+    }
+  });
+  ipcMain.handle('artifacts:write', async (_e, chatId: string, filename: string, content: string, projectPath?: string) => {
+    try {
+      return await writeArtifact(chatId, filename, content, projectPath);
+    } catch (err) {
+      console.error('[StoreHandlers] artifacts:write rejected:', errMessage(err));
+      return { success: false, error: errMessage(err) };
+    }
+  });
+  ipcMain.handle('artifacts:delete', async (_e, chatId: string, filename: string, projectPath?: string) => {
+    try {
+      return await deleteArtifact(chatId, filename, projectPath);
+    } catch (err) {
+      console.error('[StoreHandlers] artifacts:delete rejected:', errMessage(err));
+      return { success: false };
+    }
+  });
 
   // Plans
-  ipcMain.handle('plans:list', async (_e, chatId: string) => await listPlans(chatId));
-  ipcMain.handle('plans:read', async (_e, chatId: string, filename: string) => await readPlan(chatId, filename));
-  ipcMain.handle('plans:write', async (_e, chatId: string, filename: string, content: string) => await writePlan(chatId, filename, content));
-  ipcMain.handle('plans:delete', async (_e, chatId: string, filename: string) => await deletePlan(chatId, filename));
+  ipcMain.handle('plans:list', async (_e, chatId: string) => {
+    try {
+      return await listPlans(chatId);
+    } catch (err) {
+      console.error('[StoreHandlers] plans:list rejected:', errMessage(err));
+      return [];
+    }
+  });
+  ipcMain.handle('plans:read', async (_e, chatId: string, filename: string) => {
+    try {
+      return await readPlan(chatId, filename);
+    } catch (err) {
+      console.error('[StoreHandlers] plans:read rejected:', errMessage(err));
+      return null;
+    }
+  });
+  ipcMain.handle('plans:write', async (_e, chatId: string, filename: string, content: string) => {
+    try {
+      return await writePlan(chatId, filename, content);
+    } catch (err) {
+      console.error('[StoreHandlers] plans:write rejected:', errMessage(err));
+      return { success: false, error: errMessage(err) };
+    }
+  });
+  ipcMain.handle('plans:delete', async (_e, chatId: string, filename: string) => {
+    try {
+      return await deletePlan(chatId, filename);
+    } catch (err) {
+      console.error('[StoreHandlers] plans:delete rejected:', errMessage(err));
+      return { success: false };
+    }
+  });
 
   // Sites
-  ipcMain.handle('sites:list', async () => await listSites());
-  ipcMain.handle('sites:read-file', async (_e, siteName: string, filePath: string) => await readSiteFile(siteName, filePath));
-  ipcMain.handle('sites:write-file', async (_e, siteName: string, filePath: string, content: string) => await writeSiteFile(siteName, filePath, content));
-  ipcMain.handle('sites:delete', async (_e, name: string) => await deleteSite(name));
+  ipcMain.handle('sites:list', async () => {
+    try {
+      return await listSites();
+    } catch (err) {
+      console.error('[StoreHandlers] sites:list rejected:', errMessage(err));
+      return [];
+    }
+  });
+  ipcMain.handle('sites:read-file', async (_e, siteName: string, filePath: string) => {
+    try {
+      return await readSiteFile(siteName, filePath);
+    } catch (err) {
+      console.error('[StoreHandlers] sites:read-file rejected:', errMessage(err));
+      return null;
+    }
+  });
+  ipcMain.handle('sites:write-file', async (_e, siteName: string, filePath: string, content: string) => {
+    try {
+      return await writeSiteFile(siteName, filePath, content);
+    } catch (err) {
+      console.error('[StoreHandlers] sites:write-file rejected:', errMessage(err));
+      return { success: false, error: errMessage(err) };
+    }
+  });
+  ipcMain.handle('sites:delete', async (_e, name: string) => {
+    try {
+      return await deleteSite(name);
+    } catch (err) {
+      console.error('[StoreHandlers] sites:delete rejected:', errMessage(err));
+      return { success: false };
+    }
+  });
 }

--- a/main/ipc/system/hardware-handlers.ts
+++ b/main/ipc/system/hardware-handlers.ts
@@ -20,6 +20,45 @@ export const KNOWN_MODELS = [
   { model_id: "meta-llama/Meta-Llama-3.1-70B-Instruct", name: "Llama 3.1 70B", params_b: 70.6, raw_fp16_vram_gb: 141.2, quantized_q4_vram_gb: 43.5, quantized_q8_vram_gb: 78.5, min_ram_gb: 64, category: "Enterprise Frontier Model", tags: ["llama3.1:70b", "llama"] }
 ];
 
+// Fallback for Windows 11 24H2+ where wmic was removed (BK parity #4 / MP-CORR-21).
+async function getGpuInfoViaCim(): Promise<{ name: string; vramBytes: number } | null> {
+  try {
+    const { execFile } = require('child_process');
+    const { promisify } = require('util');
+    const execFileAsync = promisify(execFile);
+    // Get-CimInstance survives Win11 24H2+ where wmic was removed. Note: AdapterRAM is
+    // uint32 even via CIM, so it saturates ≈4GiB for cards with more VRAM.
+    const { stdout } = await execFileAsync('powershell.exe', [
+      '-NoProfile', '-NonInteractive', '-Command',
+      `Get-CimInstance Win32_VideoController | Select-Object Name,@{N='Vram';E={$_.AdapterRAM}} | ConvertTo-Json -Compress`,
+    ], { timeout: 8000, windowsHide: true });
+    const parsed = JSON.parse(stdout);
+    const entries = (Array.isArray(parsed) ? parsed : [parsed]).filter(Boolean);
+    if (!entries.length) return null;
+    const best = entries.reduce((acc: any, e: any) => (Number(e?.Vram ?? 0) > Number(acc?.Vram ?? 0) ? e : acc));
+    return { name: String(best?.Name ?? ''), vramBytes: Number(best?.Vram ?? 0) };
+  } catch {
+    return null;
+  }
+}
+
+function mergeCimGpuInfo(cim: { name: string; vramBytes: number } | null, gpuName: string, vramGB: number): { gpuName: string; vramGB: number; isNvidia: boolean } {
+  if (cim && cim.name && (gpuName === 'Unknown GPU' || cim.name.toLowerCase().includes('nvidia') || cim.name.toLowerCase().includes('rtx'))) {
+    gpuName = cim.name;
+  }
+  if (cim && cim.vramBytes > 0) {
+    // ≥4GB reported as 4 (AdapterRAM is uint32-saturated; registry qwMemorySize would be
+    // needed for exact). Treat saturation as a floor, not a ceiling, when gating models.
+    if (cim.vramBytes >= 4026531840) {
+      vramGB = Math.max(vramGB, 4);
+    } else {
+      vramGB = Math.max(vramGB, Math.round((cim.vramBytes / (1024 * 1024 * 1024)) * 10) / 10);
+    }
+  }
+  const isNvidia = gpuName.toLowerCase().includes('nvidia') || gpuName.toLowerCase().includes('rtx') || gpuName.toLowerCase().includes('gtx');
+  return { gpuName, vramGB, isNvidia };
+}
+
 export async function detectHardwareSpecsAsync() {
   const { exec } = require('child_process');
   const { promisify } = require('util');
@@ -53,6 +92,7 @@ export async function detectHardwareSpecsAsync() {
           isNvidia = true;
         }
       } catch {
+        let wmicResolved = false;
         try {
           const { stdout } = await execAsync('wmic path Win32_VideoController get AdapterRAM,Name,DriverVersion /format:list', { timeout: 3000 });
           for (const line of stdout.split('\n')) {
@@ -70,7 +110,11 @@ export async function detectHardwareSpecsAsync() {
             }
           }
           isNvidia = gpuName.toLowerCase().includes('nvidia') || gpuName.toLowerCase().includes('rtx') || gpuName.toLowerCase().includes('gtx');
+          wmicResolved = gpuName !== 'Unknown GPU' || vramGB > 0;
         } catch {}
+        if (!wmicResolved) {
+          ({ gpuName, vramGB, isNvidia } = mergeCimGpuInfo(await getGpuInfoViaCim(), gpuName, vramGB));
+        }
       }
     } else if (process.platform === 'darwin') {
       try {
@@ -359,6 +403,7 @@ export function registerHardwareHandlers(): void {
             isNvidia = true;
           }
         } catch {
+          let wmicResolved = false;
           try {
             const stdout = execSync('wmic path Win32_VideoController get AdapterRAM,Name /format:list', { encoding: 'utf8' });
             for (const line of stdout.split('\n')) {
@@ -373,7 +418,11 @@ export function registerHardwareHandlers(): void {
                 }
               }
             }
+            wmicResolved = gpuName !== 'Unknown GPU' || vramGB > 0;
           } catch {}
+          if (!wmicResolved) {
+            ({ gpuName, vramGB, isNvidia } = mergeCimGpuInfo(await getGpuInfoViaCim(), gpuName, vramGB));
+          }
         }
       }
 

--- a/main/ipc/system/ollama-audio-handlers.ts
+++ b/main/ipc/system/ollama-audio-handlers.ts
@@ -26,8 +26,18 @@ export function getOllamaBinary(): string {
   return 'ollama';
 }
 
+// Allow-list terminal-bound identifiers: blocks shell metacharacter injection
+// through titles and model tags coming from the renderer.
+function isSafeTerminalText(value: string): boolean {
+  return typeof value === 'string' && /^[A-Za-z0-9 ._:\/\\-]{0,80}$/.test(value);
+}
+
 export function launchNativeTerminalCommand(title: string, cmd: string): boolean {
   try {
+    if (!isSafeTerminalText(title)) {
+      console.warn('[System] Blocked terminal launch: unsafe characters in title.');
+      return false;
+    }
     const { exec } = require('child_process');
     const isWin = process.platform === 'win32';
     const isMac = process.platform === 'darwin';
@@ -207,12 +217,22 @@ async function startLocalSttServer(): Promise<number> {
 }
 
 app.on('will-quit', () => {
+  shutdownLocalStt();
+});
+
+// Exported so the before-quit shutdown chain can terminate the child even when
+// quitting via app.exit() (which skips will-quit listeners).
+export function shutdownLocalStt(): void {
   if (localSttProcess) {
     console.log('[LocalSTT] Terminating local STT server...');
-    localSttProcess.kill();
+    try {
+      localSttProcess.kill();
+    } catch (err) {
+      console.warn('[LocalSTT] Failed to kill local STT server:', err);
+    }
     localSttProcess = null;
   }
-});
+}
 
 export function registerOllamaAudioHandlers(): void {
   ipcMain.handle('system:ollama-status', async () => {
@@ -307,13 +327,18 @@ export function registerOllamaAudioHandlers(): void {
     const provider = params?.provider || 'ollama';
     const modelTag = params?.modelTag || 'llama3.2:3b';
 
+    if (!/^[A-Za-z0-9._:\/@-]{1,100}$/.test(modelTag)) {
+      console.warn('[System] Rejected pull-local-model-terminal: unsafe model tag.');
+      return { success: false, provider, modelTag, error: 'Invalid model tag: contains unsafe characters.' };
+    }
+
     let cmd = '';
     let title = '';
     if (provider === 'lmstudio') {
-      title = `Pulling model "${modelTag}" via LM Studio CLI (lms)...`;
+      title = `Pulling model ${modelTag} via LM Studio CLI lms...`;
       cmd = `lms get ${modelTag} || lms load ${modelTag}`;
     } else {
-      title = `Pulling model "${modelTag}" via Ollama...`;
+      title = `Pulling model ${modelTag} via Ollama...`;
       cmd = `ollama run ${modelTag} || ollama pull ${modelTag}`;
     }
 
@@ -325,10 +350,16 @@ export function registerOllamaAudioHandlers(): void {
     const isWin = process.platform === 'win32';
     const tag = modelTag || 'qwen3-vl:2b';
 
+    if (!/^[A-Za-z0-9._:\/@-]{1,100}$/.test(tag)) {
+      console.warn('[System] Rejected open-terminal-installer: unsafe model tag.');
+      return { success: false, error: 'Invalid model tag: contains unsafe characters.' };
+    }
+
     if (action === 'install-all') {
       const winCmd = `powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://ollama.com/install.ps1 | Invoke-Expression" && ollama pull ${tag}`;
       const unixCmd = `curl -fsSL https://ollama.com/install.sh | sh && ollama pull ${tag}`;
-      launchNativeTerminalCommand('DOWNLOADING AND INSTALLING OLLAMA & VISION MODEL', isWin ? winCmd : unixCmd);
+      const ok = launchNativeTerminalCommand('DOWNLOADING AND INSTALLING OLLAMA AND VISION MODEL', isWin ? winCmd : unixCmd);
+      return { success: ok };
     } else {
       launchNativeTerminalCommand(`PULLING MODEL: ${tag}`, `ollama run ${tag} || ollama pull ${tag}`);
     }

--- a/main/ipc/system/window-fs-handlers.ts
+++ b/main/ipc/system/window-fs-handlers.ts
@@ -2,7 +2,200 @@ import { ipcMain, dialog, shell, app } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as dns from 'dns';
 import { memorySaveTool } from '../../agent/tools/memory-save';
+
+// MP-SEC-18: typed confirmation required before wiping ~/.everfern
+export const WIPE_ACCOUNT_CONFIRM_PHRASE = 'DELETE MY DATA';
+
+// MP-SEC-09: never open system-sensitive locations via shell.openPath
+// (/private/* entries are the macOS realpath aliases of /etc and /var/root)
+const DANGEROUS_PATH_PREFIXES = ['/etc', '/system', 'c:/windows', '/private/etc', '/private/var/root'];
+
+// MP-SEC-09: shell.openPath routes through ShellExecute/LaunchServices, which
+// LAUNCH these formats instead of revealing them — deny executable payloads.
+const EXECUTABLE_OPEN_EXTENSIONS = [
+  '.exe', '.bat', '.cmd', '.scr', '.msi', '.msp', '.vbs', '.ps1',
+  '.js', '.jse', '.wsf', '.wsh', '.app', '.deb', '.rpm'
+];
+
+export const isSafeLocalOpenPath = (hostPath: string): boolean => {
+  if (!fs.existsSync(hostPath)) return false;
+  const normalized = path.normalize(hostPath).toLowerCase().replace(/\\/g, '/');
+  if (EXECUTABLE_OPEN_EXTENSIONS.includes(path.extname(normalized))) return false;
+  return !DANGEROUS_PATH_PREFIXES.some(
+    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`)
+  );
+};
+
+// MP-SEC-17: block literal private/internal hostnames to prevent SSRF probes
+const isBlockedMetadataHost = (hostname: string): boolean => {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  return (
+    host === 'localhost' ||
+    host === '::1' ||
+    host === 'metadata.google.internal' ||
+    host.endsWith('.local') ||
+    host.endsWith('.lan') ||
+    host.startsWith('127.') ||
+    host.startsWith('10.') ||
+    host.startsWith('192.168.') ||
+    host.startsWith('169.254.') ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  );
+};
+
+// WAVE-5R: expand a literal IP into bytes — dotted-quad incl. inet_aton-style
+// decimal/hex/octal shorthand (2130706433, 0x7f000001, 0177.0.0.1, 127.1) and
+// IPv6 incl. embedded/mapped v4 tails (::ffff:169.254.169.254). Non-literals
+// return null.
+export const parseIpAddress = (host: string): number[] | null => {
+  const h = host.replace(/^\[|\]$/g, '').toLowerCase();
+  if (!h) return null;
+  const ipv4Bytes = (s: string): number[] | null => {
+    const parts = s.split('.');
+    if (parts.length > 4 || parts.some((p) => p === '')) return null;
+    const nums: number[] = [];
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i];
+      let n: number;
+      if (/^0x[0-9a-f]+$/.test(p)) n = parseInt(p.slice(2), 16);
+      else if (/^0[0-7]+$/.test(p)) n = parseInt(p, 8);
+      else if (/^\d+$/.test(p)) n = parseInt(p, 10);
+      else return null;
+      if (i < parts.length - 1 && n > 255) return null;
+      nums.push(n);
+    }
+    if (nums[nums.length - 1] >= Math.pow(256, 5 - parts.length)) return null;
+    // inet_aton-style shorthand: the final part spans the remaining bytes
+    const span = 5 - parts.length;
+    let n = nums.pop() as number;
+    const rest: number[] = [];
+    for (let i = 0; i < span; i++) {
+      rest.unshift(n % 256);
+      n = Math.floor(n / 256);
+    }
+    if (n !== 0) return null;
+    return [...nums, ...rest];
+  };
+
+  if (!h.includes(':')) return ipv4Bytes(h);
+
+  // IPv6
+  const halves = h.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  if ([...head, ...tail].some((g) => g.includes('.'))) {
+    // dotted quad must be the final group; fold it into two hex groups
+    const target = tail.length && tail[tail.length - 1].includes('.') ? tail
+      : !tail.length && head.length && head[head.length - 1].includes('.') ? head
+      : null;
+    if (!target) return null;
+    const v4 = ipv4Bytes(target[target.length - 1]);
+    if (!v4) return null;
+    target.splice(target.length - 1, 1,
+      ((v4[0] << 8) | v4[1]).toString(16),
+      ((v4[2] << 8) | v4[3]).toString(16));
+  }
+  const groups = [...head, ...tail];
+  if (groups.length > 8 || (halves.length === 1 && groups.length !== 8)) return null;
+  if (!groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) return null;
+  const full = halves.length === 2
+    ? [...head, ...new Array(8 - groups.length).fill('0'), ...tail]
+    : groups;
+  const bytes: number[] = [];
+  for (const g of full) {
+    const n = parseInt(g as string, 16);
+    bytes.push((n >> 8) & 255, n & 255);
+  }
+  return bytes;
+};
+
+// WAVE-5R: true for loopback/private/link-local/CGNAT/unspecified/reserved
+// space (10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, 100.64/10, 0/8,
+// ::1, fc00::/7, fe80::/10, ::ffff:<private>).
+export const isPrivateAddress = (bytes: number[] | null): boolean => {
+  if (!bytes) return true;
+  if (bytes.length === 4) {
+    const [a, b] = bytes;
+    return (
+      a === 0 || a === 10 || a === 127 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254) ||
+      (a === 100 && b >= 64 && b <= 127)
+    );
+  }
+  if (bytes.length === 16) {
+    if (bytes.slice(0, 15).every((b) => b === 0)) return true; // :: / ::1
+    if (bytes.slice(0, 10).every((b) => b === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
+      return isPrivateAddress(bytes.slice(12)); // ::ffff:<v4>
+    }
+    const [a, b] = bytes;
+    return (a & 0xfe) === 0xfc || (a === 0xfe && (b & 0xc0) === 0x80); // fc00::/7, fe80::/10
+  }
+  return true;
+};
+
+// WAVE-5R: post-resolution SSRF guard — every DNS answer must land in public
+// space; lookup failure or a non-literal that maps private ⇒ reject.
+export const assertPublicHost = async (hostname: string): Promise<void> => {
+  const records = await dns.promises.lookup(hostname.replace(/^\[|\]$/g, ''), { all: true, verbatim: true });
+  if (!records.length) throw new Error(`no addresses resolved for ${hostname}`);
+  for (const record of records) {
+    if (isPrivateAddress(parseIpAddress(record.address))) {
+      throw new Error(`${hostname} resolves to private/reserved address ${record.address}`);
+    }
+  }
+};
+
+// WAVE-5R: SSRF-hardened metadata fetch. fetch never auto-follows
+// (redirect:'manual'); each of max 3 redirect hops re-runs scheme, literal
+// screen and resolved-address checks so a hop can't land in private space.
+const METADATA_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36';
+
+const fetchMetadataHtml = async (initialUrl: string): Promise<{ html: string; origin: string } | null> => {
+  let currentUrl = initialUrl;
+  for (let hop = 0; hop < 4; hop++) {
+    let parsed: URL;
+    try {
+      parsed = new URL(currentUrl);
+      if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+      if (isBlockedMetadataHost(parsed.hostname)) {
+        console.warn('[IPC] system:fetch-metadata: Blocked private/internal host:', parsed.hostname);
+        return null;
+      }
+      await assertPublicHost(parsed.hostname);
+    } catch (err) {
+      console.warn('[IPC] system:fetch-metadata: Blocked non-public host:', err instanceof Error ? err.message : String(err));
+      return null;
+    }
+
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 3000);
+    let response: Response;
+    try {
+      response = await fetch(parsed.href, {
+        headers: { 'User-Agent': METADATA_USER_AGENT },
+        signal: controller.signal,
+        redirect: 'manual'
+      });
+    } finally {
+      clearTimeout(id);
+    }
+
+    if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+      const location = response.headers.get('location');
+      if (!location || hop === 3) return null;
+      currentUrl = new URL(location, parsed.href).href;
+      continue;
+    }
+    if (!response.ok) return null;
+    return { html: await response.text(), origin: parsed.origin };
+  }
+  return null;
+};
 
 export function registerWindowFsHandlers(): void {
   ipcMain.handle('system:get-version', () => {
@@ -180,6 +373,11 @@ export function registerWindowFsHandlers(): void {
 
           console.log(`[IPC] system:open-external: Original file:// url: ${url}, Translated host path: ${hostPath}`);
 
+          if (!isSafeLocalOpenPath(hostPath)) {
+            console.warn('[IPC] system:open-external: Blocked unsafe or non-existent local path:', hostPath);
+            return { success: false, error: 'Blocked unsafe local path' };
+          }
+
           const resultMsg = await shell.openPath(hostPath);
           if (resultMsg) {
             return { success: false, error: resultMsg };
@@ -187,6 +385,11 @@ export function registerWindowFsHandlers(): void {
           return { success: true };
         }
 
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          console.warn('[IPC] system:open-external: Blocked non-http(s) external URL:', url);
+          return { success: false, error: 'Only http(s) URLs can be opened externally' };
+        }
         await shell.openExternal(url);
         return { success: true };
       } catch (err: any) {
@@ -200,27 +403,9 @@ export function registerWindowFsHandlers(): void {
   ipcMain.handle('system:fetch-metadata', async (_event, url: string) => {
     if (!url) return null;
     try {
-      let parsedUrl: URL;
-      try {
-        parsedUrl = new URL(url);
-        if (!['http:', 'https:'].includes(parsedUrl.protocol)) return null;
-      } catch {
-        return null;
-      }
-
-      const controller = new AbortController();
-      const id = setTimeout(() => controller.abort(), 3000);
-
-      const response = await fetch(parsedUrl.href, {
-        headers: { 
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36' 
-        },
-        signal: controller.signal
-      });
-      clearTimeout(id);
-
-      if (!response.ok) return null;
-      const html = await response.text();
+      const result = await fetchMetadataHtml(url);
+      if (!result) return null;
+      const html = result.html;
 
       const getMeta = (prop: string) => {
         const regex = new RegExp(`<meta[^>]*?(?:name|property)=["']${prop}["'][^>]*?content=["'](.*?)["']`, 'i');
@@ -255,7 +440,7 @@ export function registerWindowFsHandlers(): void {
 
       if (favicon && !favicon.startsWith('http')) {
         try {
-          favicon = new URL(favicon, parsedUrl.origin).href;
+          favicon = new URL(favicon, result.origin).href;
         } catch { /* ignore */ }
       }
 
@@ -387,7 +572,12 @@ export function registerWindowFsHandlers(): void {
     }
   });
 
-  ipcMain.handle('system:wipe-account', async () => {
+  ipcMain.handle('system:wipe-account', async (_event, confirmPhrase?: string) => {
+    if (confirmPhrase !== WIPE_ACCOUNT_CONFIRM_PHRASE) {
+      console.warn('[IPC] system:wipe-account: rejected — explicit confirmation phrase required');
+      return { success: false, error: 'Confirmation phrase required' };
+    }
+
     const everfernDir = path.join(os.homedir(), '.everfern');
     try {
       try {

--- a/main/lib/ai-client.ts
+++ b/main/lib/ai-client.ts
@@ -15,6 +15,17 @@ import { DebugEmitter } from './debug';
 import OpenAI from 'openai';
 import { CLOUD_MODEL_MAP } from './providers';
 
+// ── Local URL Normalization ─────────────────────────────────────────
+
+// Normalize localhost/::1 loopback URLs to 127.0.0.1 — Node fetch may dial ::1
+// first while Ollama/LM Studio bind IPv4 only, producing bare "fetch failed".
+export function normalizeLocalUrl(url?: string): string | undefined {
+  if (!url) return url;
+  return url
+    .replace(/^http:\/\/\[?::1\]?(:\d+)?/i, 'http://127.0.0.1$1')
+    .replace(/^http:\/\/localhost(:\d+)?/i, 'http://127.0.0.1$1');
+}
+
 // ── Safe JSON Parsing ───────────────────────────────────────────────
 
 /**
@@ -143,6 +154,8 @@ export interface AIClientConfig {
   customModel?: string;
   temperature?: number;
   maxTokens?: number;
+  /** Ollama native: context window size passed as options.num_ctx */
+  ollamaNumCtx?: number;
   /** Decoupled Vision AI configuration */
   vlm?: {
     engine: 'online' | 'local' | 'cloud';
@@ -252,9 +265,9 @@ const DEFAULT_URLS: Record<ProviderType, string> = {
   minimax: 'https://api.minimax.io/v1',
   everfern: 'https://api.everfern.app/api',  // Production EverFern API
   gemini: 'https://generativelanguage.googleapis.com/v1beta/openai',
-  ollama: 'http://localhost:11434',
+  ollama: 'http://127.0.0.1:11434',
   'ollama-cloud': 'https://ollama.com/v1',  // Fixed: was /api, should be /v1
-  lmstudio: 'http://localhost:1234/v1',
+  lmstudio: 'http://127.0.0.1:1234/v1',
   nvidia: 'https://integrate.api.nvidia.com/v1',
   openrouter: 'https://openrouter.ai/api/v1',
 };
@@ -397,8 +410,113 @@ const GEMINI_COMPUTER_USE_TOOLS = [
 
 // ── AIClient ─────────────────────────────────────────────────────────
 
+export function _formatOllamaTools(tools: any[]): any[] {
+    const sanitizeSchemaNode = (node: any, depth: number = 0): any => {
+      if (!node || typeof node !== 'object' || Array.isArray(node)) {
+        return node;
+      }
+      if (depth > 24) {
+        return node;
+      }
+
+      const clean: any = { ...node };
+
+      // Keys Ollama's schema parser cannot handle
+      delete clean.$schema;
+      delete clean.$id;
+      delete clean.examples;
+
+      // Boolean required is hoisted by the parent node — never emit it
+      if (typeof clean.required === 'boolean') {
+        delete clean.required;
+      }
+
+      // Union-typed `type` arrays like ["string","null"]: keep first non-null entry
+      if (Array.isArray(clean.type)) {
+        const nonNull = clean.type.filter((t: any) => t !== 'null');
+        clean.type = nonNull.length > 0 ? nonNull[0] : clean.type[0];
+      }
+
+      if (clean.properties && typeof clean.properties === 'object' && !Array.isArray(clean.properties)) {
+        const hoistedRequired: string[] = [];
+        const props: any = {};
+        for (const [key, val] of Object.entries(clean.properties)) {
+          if (val && typeof val === 'object' && !Array.isArray(val)) {
+            if ((val as any).required === true && !hoistedRequired.includes(key)) {
+              hoistedRequired.push(key);
+            }
+            props[key] = sanitizeSchemaNode(val, depth + 1);
+          } else {
+            props[key] = val;
+          }
+        }
+        clean.properties = props;
+        if (hoistedRequired.length > 0) {
+          clean.required = Array.isArray(clean.required) ? [...clean.required] : [];
+          for (const name of hoistedRequired) {
+            if (!clean.required.includes(name)) {
+              clean.required.push(name);
+            }
+          }
+        } else if (!Array.isArray(clean.required)) {
+          delete clean.required;
+        }
+      }
+
+      if (clean.items !== undefined) {
+        clean.items = Array.isArray(clean.items)
+          ? clean.items.map((item: any) => sanitizeSchemaNode(item, depth + 1))
+          : sanitizeSchemaNode(clean.items, depth + 1);
+      }
+
+      for (const combinator of ['anyOf', 'oneOf', 'allOf']) {
+        if (Array.isArray(clean[combinator])) {
+          clean[combinator] = clean[combinator].map((branch: any) => sanitizeSchemaNode(branch, depth + 1));
+        }
+      }
+
+      for (const defsKey of ['$defs', 'definitions']) {
+        if (clean[defsKey] && typeof clean[defsKey] === 'object' && !Array.isArray(clean[defsKey])) {
+          const defs: any = {};
+          for (const [defName, defVal] of Object.entries(clean[defsKey])) {
+            defs[defName] = sanitizeSchemaNode(defVal, depth + 1);
+          }
+          clean[defsKey] = defs;
+        }
+      }
+
+      return clean;
+    };
+
+    const sanitizeParams = (rawParams: any): any => {
+      if (!rawParams || typeof rawParams !== 'object') {
+        return { type: 'object', properties: {}, required: [] };
+      }
+      const clean = sanitizeSchemaNode(rawParams);
+      return {
+        type: clean?.type || 'object',
+        properties: (clean?.properties && typeof clean.properties === 'object') ? clean.properties : {},
+        required: Array.isArray(clean?.required) ? clean.required : []
+      };
+    };
+
+    return tools.map(t => {
+      const rawFunc = (t && (t as any).type === 'function' && (t as any).function)
+        ? (t as any).function
+        : t;
+      return {
+        type: 'function',
+        function: {
+          name: rawFunc.name,
+          description: rawFunc.description || '',
+          parameters: sanitizeParams(rawFunc.parameters)
+        }
+      };
+    });
+  }
+
 export class AIClient {
-  private config: Required<Omit<AIClientConfig, 'vlm' | 'customModel'>> & { vlm?: AIClientConfig['vlm']; customModel?: string };
+  private config: Required<Omit<AIClientConfig, 'vlm' | 'customModel' | 'ollamaNumCtx'>> & { vlm?: AIClientConfig['vlm']; customModel?: string; ollamaNumCtx?: number };
   private openaiClient?: OpenAI; // For NVIDIA NIM and DeepSeek
 
   constructor(config: AIClientConfig) {
@@ -444,6 +562,7 @@ export class AIClient {
       customModel: config.customModel,
       temperature: config.temperature ?? (config.provider === 'nvidia' ? 0.1 : 0.7),
       maxTokens: config.maxTokens ?? (config.provider === 'nvidia' ? 16383 : config.provider === 'openrouter' ? 8192 : 4096),
+      ollamaNumCtx: config.ollamaNumCtx,
       vlm: config.vlm,
     };
 
@@ -460,7 +579,7 @@ export class AIClient {
 
       this.openaiClient = new OpenAI({
         apiKey: this.config.apiKey || 'dummy-key',
-        baseURL: this.config.baseUrl,
+        baseURL: normalizeLocalUrl(this.config.baseUrl),
         timeout: 120000,
         maxRetries: 3,
         dangerouslyAllowBrowser: true,
@@ -692,9 +811,18 @@ export class AIClient {
         if (isGemini3Flash) {
           // Gemini 3 Flash via EverFern Cloud: attempt primary, fall back to gemini-2.5-flash on failure
           const FALLBACK_MODEL = 'google/gemini-2.5-flash';
+          let producedContent = false;
           try {
             console.log(`[EverFern Gemini] Trying primary model: ${modelName}`);
-            const result = await this._openAISDKChat(request);
+            const guardedRequest: ChatRequest = {
+              ...request,
+              onStreamChunk: (chunk: string) => {
+                if (chunk) producedContent = true;
+                request.onStreamChunk?.(chunk);
+              }
+            };
+            const result = await this._openAISDKChat(guardedRequest);
+            producedContent = true;
             // If empty content returned, treat as a soft failure and fall back
             const content = typeof result.content === 'string' ? result.content : '';
             if (!content.trim() && result.finishReason !== 'tool_calls') {
@@ -704,6 +832,10 @@ export class AIClient {
             }
             return result;
           } catch (err: any) {
+            if (producedContent) {
+              console.warn(`[EverFern Gemini] Primary model ${modelName} failed after content was already produced (${err?.message ?? err}) — not falling back to avoid duplicated reply`);
+              throw err;
+            }
             console.warn(`[EverFern Gemini] Primary model ${modelName} failed (${err?.message ?? err}) — falling back to ${FALLBACK_MODEL}`);
             const fallbackRequest = { ...request, model: FALLBACK_MODEL };
             return this._openAISDKChat(fallbackRequest);
@@ -897,11 +1029,22 @@ export class AIClient {
         if (isGemini3Flash) {
           // Gemini 3 Flash via EverFern Cloud: try primary, fall back to gemini-2.5-flash on error
           const FALLBACK_MODEL = 'google/gemini-2.5-flash';
+          let yieldedAny = false;
           try {
             console.log(`[EverFern Gemini Stream] Trying primary model: ${modelName}`);
-            yield* this._openAISDKStream(request);
+            const iterator = this._openAISDKStream(request);
+            while (true) {
+              const next = await iterator.next();
+              if (next.done) break;
+              yieldedAny = true;
+              yield next.value;
+            }
             return;
           } catch (err: any) {
+            if (yieldedAny) {
+              console.warn(`[EverFern Gemini Stream] Primary model ${modelName} failed mid-stream after chunks were already yielded (${err?.message ?? err}) — not falling back to avoid duplicated reply`);
+              throw err;
+            }
             console.warn(`[EverFern Gemini Stream] Primary model ${modelName} failed (${err?.message ?? err}) — falling back to ${FALLBACK_MODEL}`);
             const fallbackRequest = { ...request, model: FALLBACK_MODEL };
             yield* this._openAISDKStream(fallbackRequest);
@@ -1445,6 +1588,7 @@ export class AIClient {
 
         let fullContent = '';
         let fullReasoning = '';
+        const thinkState = { inThinking: false };
         const toolCallsMap: Record<number, { id: string; name: string; arguments: string }> = {};
         let finishReason: any = 'stop';
         let responseId = `${this.config.provider}-${Date.now()}`;
@@ -1457,13 +1601,23 @@ export class AIClient {
           }
           const delta = chunk.choices?.[0]?.delta;
 
+          if ((delta as any)?.reasoning_content) {
+            const piece = (delta as any).reasoning_content as string;
+            fullReasoning += piece;
+            if (!thinkState.inThinking) {
+              thinkState.inThinking = true;
+              req.onStreamChunk?.(`<think>${piece}`);
+            } else {
+              req.onStreamChunk?.(piece);
+            }
+          } else if (delta?.content && thinkState.inThinking) {
+            thinkState.inThinking = false;
+            req.onStreamChunk?.('</think>');
+          }
+
           if (delta?.content) {
             fullContent += delta.content;
             req.onStreamChunk!(delta.content);
-          }
-
-          if ((delta as any)?.reasoning_content) {
-            fullReasoning += (delta as any).reasoning_content;
           }
 
           if (delta?.tool_calls) {
@@ -1487,6 +1641,11 @@ export class AIClient {
           if (chunk.choices?.[0]?.finish_reason) {
             finishReason = chunk.choices[0].finish_reason;
           }
+        }
+
+        if (thinkState.inThinking) {
+          thinkState.inThinking = false;
+          req.onStreamChunk?.('</think>');
         }
 
         const toolCalls = Object.values(toolCallsMap).map(tc => ({
@@ -1656,20 +1815,42 @@ export class AIClient {
         this.openaiClient!.chat.completions.create(options) as unknown as Promise<AsyncIterable<any>>
       );
       let id = `${this.config.provider}-${Date.now()}`;
+      const thinkState = { inThinking: false };
 
       for await (const chunk of stream) {
         if (chunk.id) id = chunk.id;
         const delta = chunk.choices?.[0]?.delta;
 
-        yield {
-          id,
-          delta: delta?.content ?? '',
-          toolCalls: delta?.tool_calls,
-          done: false,
-          model: chunk.model
-        };
+        if ((delta as any)?.reasoning_content) {
+          const piece = (delta as any).reasoning_content as string;
+          if (!thinkState.inThinking) {
+            thinkState.inThinking = true;
+            yield { id, delta: `<think>${piece}`, done: false, model: chunk.model };
+          } else {
+            yield { id, delta: piece, done: false, model: chunk.model };
+          }
+        }
+
+        if (delta?.content && thinkState.inThinking) {
+          thinkState.inThinking = false;
+          yield { id, delta: '</think>', done: false };
+        }
+
+        if (delta?.content || delta?.tool_calls) {
+          yield {
+            id,
+            delta: delta?.content ?? '',
+            toolCalls: delta?.tool_calls,
+            done: false,
+            model: chunk.model
+          };
+        }
 
         if (chunk.choices?.[0]?.finish_reason) {
+          if (thinkState.inThinking) {
+            thinkState.inThinking = false;
+            yield { id, delta: '</think>', done: false };
+          }
           yield { id, delta: '', done: true };
           return;
         }
@@ -1693,30 +1874,35 @@ export class AIClient {
     }
   }
 
-  async healthCheck(): Promise<{ ok: boolean; latencyMs?: number; error?: string }> {
+  async healthCheck(): Promise<{ ok: boolean; latencyMs?: number; error?: string; reason?: string }> {
     const start = Date.now();
     try {
       const models = await this.listModels();
-      return { ok: models.length >= 0, latencyMs: Date.now() - start };
+      if (models.length === 0) {
+        return { ok: models.length > 0, reason: 'No models reported — is the server running?', latencyMs: Date.now() - start };
+      }
+      return { ok: models.length > 0, latencyMs: Date.now() - start };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   }
 
   private async _fetchWithRetry(url: string, options: RequestInit, maxRetries = 6): Promise<Response> {
+    // Normalize loopback hosts (::1/localhost → 127.0.0.1) so Node fetch doesn't dial IPv6 first
+    const requestUrl = normalizeLocalUrl(url) ?? url;
     let lastError: Error | null = null;
     let delay = 1000; // Start with 1s instead of 2s for faster initial retry
 
     for (let i = 0; i <= maxRetries; i++) {
       try {
-        if (url.includes('nvidia') || i > 0) {
-          console.log(`[AIClient] Fetching: ${url} (Attempt ${i + 1}/${maxRetries + 1})`);
+        if (requestUrl.includes('nvidia') || i > 0) {
+          console.log(`[AIClient] Fetching: ${requestUrl} (Attempt ${i + 1}/${maxRetries + 1})`);
         }
 
         // Create a new AbortController for each attempt with timeout
         // Increase timeout to 5 minutes (300000ms) for local providers to prevent cold-start failures
         const controller = new AbortController();
-        const isLocal = this.isLocal() || url.includes('localhost') || url.includes('127.0.0.1');
+        const isLocal = this.isLocal() || requestUrl.includes('localhost') || requestUrl.includes('127.0.0.1');
         const timeoutMs = isLocal ? 300000 : 60000;
         const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -1733,7 +1919,7 @@ export class AIClient {
         };
 
         try {
-          const res = await fetch(url, enhancedOptions);
+          const res = await fetch(requestUrl, enhancedOptions);
           clearTimeout(timeoutId);
 
           if (res.status === 429 || (res.status >= 500 && res.status <= 599)) {
@@ -1755,27 +1941,28 @@ export class AIClient {
         lastError = err instanceof Error ? err : new Error(String(err));
 
         // If local daemon (Ollama 11434, LM Studio 1234, local server) is offline, fail fast immediately without noisy retries
-        const isLocalEndpoint = url.includes('11434') || url.includes('1234') || url.includes('localhost') || url.includes('127.0.0.1');
+        const isLocalEndpoint = requestUrl.includes('11434') || requestUrl.includes('1234') || requestUrl.includes('localhost') || requestUrl.includes('127.0.0.1');
         if (isLocalEndpoint && (lastError.message.includes('fetch failed') || (lastError as any).cause?.code === 'ECONNREFUSED' || lastError.message.includes('ECONNREFUSED'))) {
-          console.log(`[AIClient] Local endpoint offline (${url}), failing fast.`);
-          throw lastError;
+          console.log(`[AIClient] Local endpoint offline (${requestUrl}), failing fast.`);
+          const providerLabel = requestUrl.includes('11434') ? 'Ollama' : 'LM Studio';
+          throw new Error(`${providerLabel} not reachable at ${requestUrl} (${(lastError as any)?.cause?.code ?? lastError?.message}). Start the server or fix Settings → Base URL.`);
         }
 
         // Check if it's an abort error (timeout)
         if (lastError.name === 'AbortError') {
           console.warn(`[AIClient] Request timeout after 30s. Retrying...`);
           // Log Ollama-specific timeout info
-          if (url.includes('/api/chat')) {
-            console.log(`[Ollama] Timeout on ${url} - No response received within timeout window`);
+          if (requestUrl.includes('/api/chat')) {
+            console.log(`[Ollama] Timeout on ${requestUrl} - No response received within timeout window`);
           }
         } else {
           console.warn(`[AIClient] Network error: ${lastError.message}. Retrying in ${delay}ms...`);
           // Log error details for debugging
-          if (url.includes('/api/chat')) {
+          if (requestUrl.includes('/api/chat')) {
             console.log(`[Ollama] Error details:`, {
               message: lastError.message,
               name: lastError.name,
-              url: url
+              url: requestUrl
             });
           }
         }
@@ -1787,7 +1974,7 @@ export class AIClient {
         }
       }
     }
-    throw lastError || new Error(`Failed to fetch ${url} after ${maxRetries + 1} attempts`);
+    throw lastError || new Error(`Failed to fetch ${requestUrl} after ${maxRetries + 1} attempts`);
   }
 
   // ── OpenAI-Compatible (OpenAI, DeepSeek, LM Studio, EverFern) ───
@@ -2311,7 +2498,7 @@ export class AIClient {
     try {
       const isLocal = this.isLocal() || this.config.provider === 'lmstudio' || this.config.baseUrl.includes('localhost') || this.config.baseUrl.includes('127.0.0.1');
       const retries = isLocal ? 0 : 2;
-      const res = await this._fetchWithRetry(`${this.config.baseUrl}/models`, { headers: this._oaiHeaders }, retries);
+      const res = await this._fetchWithRetry(`${normalizeLocalUrl(this.config.baseUrl) ?? this.config.baseUrl}/models`, { headers: this._oaiHeaders }, retries);
       if (!res.ok) return [];
       const data = await res.json();
       const rawModels = Array.isArray(data.data)
@@ -2649,6 +2836,7 @@ export class AIClient {
     const toolCallsMap: Record<number, { id: string; name: string; arguments: string }> = {};
     let finishReason: any = 'stop';
     let responseId = `anthropic-${Date.now()}`;
+    const thinkState = { inThinking: false };
 
     while (true) {
       const { done, value } = await reader.read();
@@ -2665,7 +2853,20 @@ export class AIClient {
           if (d.type === 'message_start') {
             responseId = d.message?.id ?? responseId;
           }
+          if (d.type === 'content_block_delta' && d.delta?.type === 'thinking_delta') {
+            const piece = d.delta.thinking ?? '';
+            if (!thinkState.inThinking) {
+              thinkState.inThinking = true;
+              req.onStreamChunk?.(`<think>${piece}`);
+            } else {
+              req.onStreamChunk?.(piece);
+            }
+          }
           if (d.type === 'content_block_delta' && d.delta?.type === 'text_delta') {
+            if (thinkState.inThinking) {
+              thinkState.inThinking = false;
+              req.onStreamChunk?.('</think>');
+            }
             fullContent += d.delta.text;
             req.onStreamChunk!(d.delta.text);
           }
@@ -2685,6 +2886,11 @@ export class AIClient {
           }
         } catch { }
       }
+    }
+
+    if (thinkState.inThinking) {
+      thinkState.inThinking = false;
+      req.onStreamChunk?.('</think>');
     }
 
     const toolCalls = Object.values(toolCallsMap).map((tc: any) => ({
@@ -2755,6 +2961,7 @@ export class AIClient {
     const dec = new TextDecoder();
     let buf = '';
     let id = `anthropic-${Date.now()}`;
+    const thinkState = { inThinking: false };
 
     while (true) {
       const { done, value } = await reader.read();
@@ -2770,9 +2977,27 @@ export class AIClient {
           const d = JSON.parse(t.slice(6));
           if (d.type === 'message_start') id = d.message?.id ?? id;
           if (d.type === 'content_block_delta') {
-            yield { id, delta: d.delta?.text ?? '', done: false };
+            if (d.delta?.type === 'thinking_delta') {
+              const piece = d.delta.thinking ?? '';
+              if (!thinkState.inThinking) {
+                thinkState.inThinking = true;
+                yield { id, delta: `<think>${piece}`, done: false };
+              } else {
+                yield { id, delta: piece, done: false };
+              }
+            } else {
+              if (d.delta?.type === 'text_delta' && thinkState.inThinking) {
+                thinkState.inThinking = false;
+                yield { id, delta: '</think>', done: false };
+              }
+              yield { id, delta: d.delta?.text ?? '', done: false };
+            }
           }
           if (d.type === 'message_stop') {
+            if (thinkState.inThinking) {
+              thinkState.inThinking = false;
+              yield { id, delta: '</think>', done: false };
+            }
             yield { id, delta: '', done: true }; return;
           }
         } catch { /* skip */ }
@@ -2842,61 +3067,6 @@ export class AIClient {
     });
   }
 
-  private _formatOllamaTools(tools: any[]): any[] {
-    const sanitizeParams = (rawParams: any): any => {
-      if (!rawParams || typeof rawParams !== 'object') {
-        return { type: 'object', properties: {}, required: [] };
-      }
-
-      const clean: any = {
-        type: rawParams.type || 'object',
-        properties: {},
-        required: Array.isArray(rawParams.required) ? [...rawParams.required] : []
-      };
-
-      if (rawParams.properties && typeof rawParams.properties === 'object') {
-        for (const [key, val] of Object.entries(rawParams.properties)) {
-          if (val && typeof val === 'object') {
-            const propCopy: any = { ...(val as any) };
-            if (typeof propCopy.required === 'boolean') {
-              if (propCopy.required && !clean.required.includes(key)) {
-                clean.required.push(key);
-              }
-              delete propCopy.required;
-            } else if (Array.isArray(propCopy.required)) {
-              delete propCopy.required;
-            }
-            if (propCopy.properties && typeof propCopy.properties === 'object') {
-              propCopy.properties = sanitizeParams(propCopy).properties;
-            }
-            clean.properties[key] = propCopy;
-          } else {
-            clean.properties[key] = val;
-          }
-        }
-      }
-
-      if (!Array.isArray(clean.required)) {
-        clean.required = [];
-      }
-
-      return clean;
-    };
-
-    return tools.map(t => {
-      const rawFunc = (t && (t as any).type === 'function' && (t as any).function)
-        ? (t as any).function
-        : t;
-      return {
-        type: 'function',
-        function: {
-          name: rawFunc.name,
-          description: rawFunc.description || '',
-          parameters: sanitizeParams(rawFunc.parameters)
-        }
-      };
-    });
-  }
 
   private async _ollamaChat(req: ChatRequest): Promise<ChatResponse> {
     const isStreaming = !!req.onStreamChunk;
@@ -2919,9 +3089,10 @@ export class AIClient {
       model: req.model ?? this.config.model,
       messages,
       stream: isStreaming,
+      keep_alive: '30m',
       options: {
         temperature: req.temperature ?? this.config.temperature ?? 0.2,
-        num_ctx: 16384,
+        num_ctx: this.config.ollamaNumCtx ?? 16384,
         num_predict: 4096,
       },
     };
@@ -2929,7 +3100,7 @@ export class AIClient {
 
     // Pass tools to Ollama if provided
     if (req.tools && req.tools.length > 0) {
-      body['tools'] = this._formatOllamaTools(req.tools);
+      body['tools'] = _formatOllamaTools(req.tools);
     }
 
     const headers = this._ollamaHeaders;
@@ -3005,6 +3176,7 @@ export class AIClient {
     let lineBuffer = '';
 
     const toolCallsMap: Record<number, { id: string; name: string; arguments: string }> = {};
+    const thinkState = { inThinking: false };
 
     while (true) {
       const { done, value } = await reader.read();
@@ -3019,6 +3191,19 @@ export class AIClient {
         if (!line.trim()) continue;
         try {
           const d = JSON.parse(line);
+          const thinkingPiece = d.message?.thinking ?? d.message?.reasoning;
+          if (thinkingPiece) {
+            if (!thinkState.inThinking) {
+              thinkState.inThinking = true;
+              req.onStreamChunk?.(`<think>${thinkingPiece}`);
+            } else {
+              req.onStreamChunk?.(thinkingPiece);
+            }
+          } else if (d.message?.content && thinkState.inThinking) {
+            thinkState.inThinking = false;
+            req.onStreamChunk?.('</think>');
+          }
+
           if (d.message?.content) {
             fullContent += d.message.content;
             req.onStreamChunk!(d.message.content);
@@ -3051,6 +3236,11 @@ export class AIClient {
       }
     }
 
+    if (thinkState.inThinking) {
+      thinkState.inThinking = false;
+      req.onStreamChunk?.('</think>');
+    }
+
     const toolCalls = Object.values(toolCallsMap).map(tc => {
       const args = safeParseJSON(tc.arguments);
       return { id: tc.id, name: tc.name, arguments: args as Record<string, any> };
@@ -3075,16 +3265,17 @@ export class AIClient {
       model: req.model ?? this.config.model,
       messages: this._mapOllamaMessages(req.messages),
       stream: true,
+      keep_alive: '30m',
       options: {
         temperature: req.temperature ?? this.config.temperature ?? 0.2,
-        num_ctx: 16384,
+        num_ctx: this.config.ollamaNumCtx ?? 16384,
         num_predict: 4096,
       },
     };
 
     // Pass tools to Ollama if provided (mirrors non-streaming path)
     if (req.tools && req.tools.length > 0) {
-      body['tools'] = this._formatOllamaTools(req.tools);
+      body['tools'] = _formatOllamaTools(req.tools);
     }
 
     const res = await this._fetchWithRetry(`${this.config.baseUrl}/api/chat`, {
@@ -3108,6 +3299,7 @@ export class AIClient {
     const dec = new TextDecoder();
     const id = `ollama-${Date.now()}`;
     let buffer = '';
+    const thinkState = { inThinking: false };
 
     while (true) {
       const { done, value } = await reader.read();
@@ -3130,6 +3322,23 @@ export class AIClient {
                 req.onToolCallChunk(i, tc.function?.name || tc.name || '', argsDelta);
               }
             }
+          }
+          const thinkingPiece = d.message?.thinking ?? d.message?.reasoning;
+          if (thinkingPiece) {
+            if (!thinkState.inThinking) {
+              thinkState.inThinking = true;
+              yield { id, delta: `<think>${thinkingPiece}`, done: false, model: d.model };
+            } else {
+              yield { id, delta: thinkingPiece, done: false, model: d.model };
+            }
+          }
+          if (d.message?.content && thinkState.inThinking) {
+            thinkState.inThinking = false;
+            yield { id, delta: '</think>', done: false };
+          }
+          if (d.done && thinkState.inThinking) {
+            thinkState.inThinking = false;
+            yield { id, delta: '</think>', done: false };
           }
           yield {
             id,

--- a/main/lib/cache.ts
+++ b/main/lib/cache.ts
@@ -10,6 +10,7 @@ const CACHE_TIMEOUT_MS = 5000;
 let isCacheDisabled = false;
 let cacheHealthy = true;
 let lastHealthCheck = 0;
+let cacheSavepointCounter = 0;
 const HEALTH_CHECK_INTERVAL = 60000; // 1 minute
 
 // Circuit breaker pattern for cache reliability
@@ -48,11 +49,16 @@ class CacheCircuitBreaker {
 const circuitBreaker = new CacheCircuitBreaker();
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  const timeoutPromise = new Promise<never>((_, reject) => 
-    setTimeout(() => reject(new Error('Cache operation timed out')), timeoutMs)
-  );
+  let timer: ReturnType<typeof setTimeout>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('Cache operation timed out')), timeoutMs);
+  });
   
-  return Promise.race([promise, timeoutPromise]);
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timer!);
+  }
 }
 
 async function checkCacheHealth(): Promise<boolean> {
@@ -151,6 +157,10 @@ export async function saveCache(prompt: string, response: ChatResponse) {
     return;
   }
 
+  // Unique-named SAVEPOINT instead of BEGIN/COMMIT to avoid colliding with
+  // other SAVEPOINT users of the shared connection under concurrency.
+  const spName = `sp_cache_${Date.now()}_${++cacheSavepointCounter}`;
+
   for (let attempt = 1; attempt <= CACHE_RETRY_ATTEMPTS; attempt++) {
     try {
       const config = getSystemEmbeddingConfig();
@@ -165,7 +175,7 @@ export async function saveCache(prompt: string, response: ChatResponse) {
       );
       const vectorBuffer = Buffer.from(new Float32Array(promptVector).buffer);
 
-      await withTimeout(dbOps.run('BEGIN TRANSACTION'), CACHE_TIMEOUT_MS);
+      await withTimeout(dbOps.run(`SAVEPOINT ${spName}`), CACHE_TIMEOUT_MS);
       try {
         await withTimeout(
           dbOps.run(
@@ -178,14 +188,15 @@ export async function saveCache(prompt: string, response: ChatResponse) {
           dbOps.run('INSERT OR REPLACE INTO semantic_cache_vec (id, embedding) VALUES (?, ?)', [id, vectorBuffer]),
           CACHE_TIMEOUT_MS
         );
-        await withTimeout(dbOps.run('COMMIT'), CACHE_TIMEOUT_MS);
+        await withTimeout(dbOps.run(`RELEASE SAVEPOINT ${spName}`), CACHE_TIMEOUT_MS);
         
         console.log('[Optima] Saved to Semantic Cache');
         circuitBreaker.recordSuccess();
         return;
         
       } catch (e) {
-        await dbOps.run('ROLLBACK').catch(() => {}); // Ignore rollback errors
+        await dbOps.run(`ROLLBACK TO SAVEPOINT ${spName}`).catch(() => {}); // Ignore rollback errors
+        await dbOps.run(`RELEASE SAVEPOINT ${spName}`).catch(() => {});
         throw e;
       }
     } catch (err) {

--- a/main/lib/db.ts
+++ b/main/lib/db.ts
@@ -7,6 +7,7 @@ import { runMigrations } from './migrations/runner';
 import { initializePersistenceTables, migratePersistenceSchema } from '../store/persistence-db';
 
 let instance: sqlite3.Database | null = null;
+let instancePromise: Promise<sqlite3.Database> | null = null;
 let currentVectorDims: number | null = null;
 
 function dbRunPromise(db: sqlite3.Database, sql: string, params: any[] = []): Promise<void> {
@@ -342,9 +343,17 @@ export async function initMemoryDb(): Promise<sqlite3.Database> {
   });
 }
 
-export async function getDb(): Promise<sqlite3.Database> {
-  if (!instance) return await initMemoryDb();
-  return instance;
+export function getDb(): Promise<sqlite3.Database> {
+  // Re-entrant fast path: continueWithSetup sets `instance` before running
+  // migrations, and those migrations call back into getDb() via dbOps.
+  if (instance) return Promise.resolve(instance);
+  if (!instancePromise) {
+    instancePromise = initMemoryDb().catch((err) => {
+      instancePromise = null;
+      throw err;
+    });
+  }
+  return instancePromise;
 }
 
 export function closeDb(): Promise<void> {
@@ -353,6 +362,7 @@ export function closeDb(): Promise<void> {
       instance.close((err) => {
         if (err) return reject(err);
         instance = null;
+        instancePromise = null;
         resolve();
       });
     } else {

--- a/main/lib/debug.ts
+++ b/main/lib/debug.ts
@@ -16,13 +16,36 @@ const GRAY = '\x1b[90m';
 const BOLD = '\x1b[1m';
 
 DebugEmitter.on('log', (entry: { time: string; level: 'info' | 'warn' | 'error'; title: string; data: any }) => {
-  logs.push(entry);
+  const sanitized = { ...entry, data: capLength(typeof entry.data === 'string' ? entry.data : safeStringify(entry.data)) };
+  logs.push(sanitized);
   if (logs.length > 2000) logs.shift(); // Keep last 2000 logs in memory
 
   if (debugWin && !debugWin.isDestroyed()) {
-    debugWin.webContents.executeJavaScript(`window.appendLog(${JSON.stringify(JSON.stringify(entry))})`).catch(() => {});
+    debugWin.webContents.executeJavaScript(`window.appendLog(${JSON.stringify(JSON.stringify(sanitized))})`).catch(() => {});
   }
 });
+
+// Safe + lazy-ish stringify: circular structures and BigInts must never throw,
+// and oversized payloads are truncated to keep the debug ring cheap.
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet();
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (typeof val === 'bigint') return `${val}n`;
+      if (typeof val === 'object' && val !== null) {
+        if (seen.has(val)) return '[Circular]';
+        seen.add(val);
+      }
+      return val;
+    }) ?? String(value);
+  } catch {
+    return '[Unserializable]';
+  }
+}
+
+function capLength(s: string): string {
+  return s.length > 2000 ? `${s.slice(0, 2000)}…` : s;
+}
 
 /**
  * Hooks into console.log/warn/error to enhance terminal output with ANSI colors
@@ -41,7 +64,7 @@ export function setupLogging() {
 
       // Format terminal line with ANSI colors
       if (typeof firstArg === 'string' && (firstArg.startsWith('[') || firstArg.startsWith('('))) {
-        const formatted = `${GRAY}[${timeStr}]${RESET} ${CYAN}${BOLD}${args[0]}${RESET} ${args.slice(1).map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`;
+        const formatted = `${GRAY}[${timeStr}]${RESET} ${CYAN}${BOLD}${args[0]}${RESET} ${args.slice(1).map(a => capLength(typeof a === 'string' ? a : safeStringify(a))).join(' ')}`;
         originalLog.call(console, formatted);
       } else {
         originalLog.apply(console, args);
@@ -59,7 +82,7 @@ export function setupLogging() {
 
     console.warn = (...args: any[]) => {
       const timeStr = new Date().toLocaleTimeString();
-      const formatted = `${GRAY}[${timeStr}]${RESET} ${YELLOW}${BOLD}⚠️ ${args[0]}${RESET} ${args.slice(1).map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`;
+      const formatted = `${GRAY}[${timeStr}]${RESET} ${YELLOW}${BOLD}⚠️ ${args[0]}${RESET} ${args.slice(1).map(a => capLength(typeof a === 'string' ? a : safeStringify(a))).join(' ')}`;
       originalWarn.call(console, formatted);
 
       try {
@@ -74,7 +97,7 @@ export function setupLogging() {
 
     console.error = (...args: any[]) => {
       const timeStr = new Date().toLocaleTimeString();
-      const formatted = `${GRAY}[${timeStr}]${RESET} ${RED}${BOLD}❌ ${args[0]}${RESET} ${args.slice(1).map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`;
+      const formatted = `${GRAY}[${timeStr}]${RESET} ${RED}${BOLD}❌ ${args[0]}${RESET} ${args.slice(1).map(a => capLength(typeof a === 'string' ? a : safeStringify(a))).join(' ')}`;
       originalError.call(console, formatted);
 
       try {
@@ -380,7 +403,11 @@ export function toggleDebugWindow() {
 
   debugWin.webContents.on('did-finish-load', () => {
     logs.forEach(entry => {
-      debugWin!.webContents.executeJavaScript(`window.appendLog(${JSON.stringify(JSON.stringify(entry))})`).catch(() => {});
+      try {
+        debugWin!.webContents.executeJavaScript(`window.appendLog(${JSON.stringify(JSON.stringify(entry))})`).catch(() => {});
+      } catch (e) {
+        console.warn('[Debug] Skipped unserializable log entry during replay:', e);
+      }
     });
   });
 

--- a/main/lib/dispatch.ts
+++ b/main/lib/dispatch.ts
@@ -5,6 +5,8 @@ import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
 
+let lifecycleHandlersInstalled = false;
+
 export class DispatchService {
   private static instance: DispatchService;
   private supabase: SupabaseClient | null = null;
@@ -84,8 +86,9 @@ export class DispatchService {
       auth: { token: config.token },
       transports: ['websocket', 'polling'],   // prefer WebSocket, fall back to polling
       reconnection: true,
-      reconnectionAttempts: Infinity,
+      reconnectionAttempts: 10,
       reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
     });
 
     this.socket.on('connect', () => {
@@ -95,6 +98,16 @@ export class DispatchService {
 
     this.socket.on('connect_error', (err) => {
       console.error('[DispatchService] Socket connect_error:', err.message);
+    });
+
+    this.socket.on('reconnect_failed', () => {
+      console.warn('[DispatchService] Socket gave up reconnecting after 10 attempts.');
+      // Periodic self-heal every 5 minutes after give-up.
+      setTimeout(() => {
+        try {
+          if (!this.socket?.connected) this.socket?.connect();
+        } catch {}
+      }, 300000).unref?.();
     });
 
     this.socket.on('disconnect', (reason) => {
@@ -129,9 +142,12 @@ export class DispatchService {
       }
     });
 
-    // Graceful shutdown
-    process.on('exit', () => this.disconnect());
-    process.on('SIGINT', () => { this.disconnect().then(() => process.exit(0)); });
+    // Graceful shutdown — install lifecycle handlers only once
+    // (Electron/main owns shutdown signals like SIGINT)
+    if (!lifecycleHandlersInstalled) {
+      lifecycleHandlersInstalled = true;
+      process.on('exit', () => this.disconnect());
+    }
 
     // Only create a new session if we actually have pairing credentials.
     // When restoring an existing session, these will be empty.

--- a/main/lib/extension-server.ts
+++ b/main/lib/extension-server.ts
@@ -1,6 +1,13 @@
 import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID, timingSafeEqual } from 'crypto';
 import { EventEmitter } from 'events';
 import { WebSocketServer, WebSocket } from 'ws';
+
+const EXTENSION_ORIGIN_PATTERNS = [/^chrome-extension:\/\//i, /^moz-extension:\/\//i];
+const DEV_ORIGIN_PATTERN = /^http:\/\/localhost:(3001|5173)(?:\/|$)/;
 
 /**
  * EverFern Localhost Bridge Server (WebSocket Edition)
@@ -15,15 +22,75 @@ class ExtensionBridgeServer extends EventEmitter {
   private activeSessions: Map<string, { id: string; url: string; title: string }> = new Map();
   private nextRequestId = 1;
   private pendingRequests = new Map<string, { resolve: (value: any) => void; reject: (reason?: any) => void; timeout: NodeJS.Timeout }>();
+  private bridgeToken = '';
+  private lastUpgradeRejectLogAt = 0;
+
+  /**
+   * Pairing token for defense-in-depth on the localhost bridge (MP-SEC-06).
+   * Loaded once per server start; persisted to ~/.everfern/bridge-token.json (0600).
+   * The 0600 hardening is POSIX-only: Windows ignores chmod and relies on its
+   * same-user permission model instead.
+   */
+  getBridgeToken(): string {
+    return this.bridgeToken;
+  }
+
+  private isAllowedHttpOrigin(origin: string): boolean {
+    if (EXTENSION_ORIGIN_PATTERNS.some(p => p.test(origin))) return true;
+    if (process.env.NODE_ENV !== 'production' && DEV_ORIGIN_PATTERN.test(origin)) return true;
+    return false;
+  }
+
+  private tokenMatches(candidate: string | null): boolean {
+    if (!candidate || !this.bridgeToken) return false;
+    const a = Buffer.from(candidate);
+    const b = Buffer.from(this.bridgeToken);
+    return a.length === b.length && timingSafeEqual(a, b);
+  }
+
+  private loadBridgeToken() {
+    const tokenFile = path.join(os.homedir(), '.everfern', 'bridge-token.json');
+    try {
+      const parsed = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
+      if (parsed && typeof parsed.token === 'string' && parsed.token) {
+        this.bridgeToken = parsed.token;
+        // Re-harden pre-existing token files that may have been written with
+        // looser modes (POSIX only — Windows ignores chmod, see JSDoc above).
+        if (process.platform !== 'win32') fs.chmodSync(tokenFile, 0o600);
+        return;
+      }
+    } catch { /* regenerate below */ }
+    this.bridgeToken = randomUUID();
+    try {
+      fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
+      fs.writeFileSync(tokenFile, JSON.stringify({ token: this.bridgeToken }), { mode: 0o600 });
+      fs.chmodSync(tokenFile, 0o600);
+    } catch (e) {
+      console.warn('[BridgeServer] ⚠️ Could not persist bridge token:', e);
+    }
+  }
+
+  private logRejectedUpgrade(origin: string | undefined) {
+    const now = Date.now();
+    if (now - this.lastUpgradeRejectLogAt < 60000) return;
+    this.lastUpgradeRejectLogAt = now;
+    console.warn(`[BridgeServer] 🚫 Rejected WebSocket upgrade from unauthorized origin: ${origin ? origin.slice(0, 100) : '<none>'}`);
+  }
 
   start() {
     if (this.server) return;
 
+    this.loadBridgeToken();
+
     this.server = http.createServer((req, res) => {
-      // CORS headers
-      res.setHeader('Access-Control-Allow-Origin', '*');
+      // CORS: reflect Origin only for known extension/dev origins (MP-SEC-06)
+      const origin = req.headers.origin;
+      if (origin && this.isAllowedHttpOrigin(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Vary', 'Origin');
+      }
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-everfern-bridge');
 
       if (req.method === 'OPTIONS') {
         res.writeHead(204);
@@ -32,6 +99,17 @@ class ExtensionBridgeServer extends EventEmitter {
       }
 
       const url = new URL(req.url || '', `http://localhost:${this.port}`);
+
+      // CSRF guard: state-changing requests must carry a non-forgeable custom header
+      if (
+        (url.pathname === '/event' || url.pathname === '/wake') &&
+        req.method !== 'GET' &&
+        req.headers['x-everfern-bridge'] !== '1'
+      ) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
 
       // ── HTTP Routes ───────────────────────────────────────────────────────
 
@@ -177,7 +255,20 @@ class ExtensionBridgeServer extends EventEmitter {
     });
 
     // ── WebSocket Server ──────────────────────────────────────────────────
-    this.wss = new WebSocketServer({ server: this.server });
+    this.wss = new WebSocketServer({ noServer: true });
+
+    // Origin/token validation on upgrade (MP-SEC-06)
+    this.server.on('upgrade', (req, socket, head) => {
+      const origin = req.headers.origin;
+      const isExtensionOrigin = !!origin && EXTENSION_ORIGIN_PATTERNS.some(p => p.test(origin));
+      const token = new URL(req.url || '', `http://localhost:${this.port}`).searchParams.get('token');
+      if (!isExtensionOrigin && !this.tokenMatches(token)) {
+        socket.destroy();
+        this.logRejectedUpgrade(origin);
+        return;
+      }
+      this.wss!.handleUpgrade(req, socket, head, ws => this.wss!.emit('connection', ws, req));
+    });
 
     this.wss.on('connection', (ws) => {
       console.log('[BridgeServer] 🔌 Extension connected via WebSocket');

--- a/main/lib/file-associations.ts
+++ b/main/lib/file-associations.ts
@@ -8,11 +8,12 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { exec } from 'child_process';
+import { exec, execFile, SpawnOptions } from 'child_process';
 import { promisify } from 'util';
 import { app, shell } from 'electron';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface FileApp {
   name: string;       // Display name
@@ -120,9 +121,22 @@ export async function openFileWithApp(filePath: string, appPath?: string): Promi
   }
 
   if (platform === 'win32') {
-    await execAsync(`start "" "${appPath}" "${filePath}"`);
+    const proc = require('child_process').spawn(
+      'cmd.exe',
+      ['/d', '/s', '/c', 'start', '', appPath, filePath],
+      { windowsHide: true, detached: true, stdio: 'ignore' }
+    );
+    proc.unref();
+    await new Promise<void>((resolve, reject) => {
+      proc.once('error', reject);
+      proc.once('close', (code: number | null) => {
+        if (code) reject(new Error(`start exited with code ${code}`));
+        else resolve();
+      });
+    });
   } else if (platform === 'darwin') {
-    await execAsync(`open -a "${appPath}" "${filePath}"`);
+    const openOpts: SpawnOptions = { detached: true, stdio: 'ignore' };
+    await execFileAsync('open', ['-a', appPath, filePath], openOpts);
   } else {
     // Linux: most apps can be launched directly
     const proc = require('child_process').spawn(appPath, [filePath], {

--- a/main/lib/path-guard.ts
+++ b/main/lib/path-guard.ts
@@ -1,0 +1,74 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Containment guard for renderer-supplied path segments. Resolves symlinks so a
+// link planted inside a sandbox dir cannot escape it.
+
+function contained(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  return child.startsWith(parent.endsWith(path.sep) ? parent : parent + path.sep);
+}
+
+/**
+ * Resolves `segments` under `root` and guarantees the result cannot escape it,
+ * both lexically ('..' climbs, absolute overrides) and physically (symlinks).
+ * Throws when containment would be violated.
+ */
+export function resolveWithin(root: string, ...segments: string[]): string {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...segments);
+
+  // String-level containment FIRST: rejects traversal and absolute targets.
+  if (!contained(resolved, resolvedRoot)) {
+    throw new Error(`Path escapes sandbox root: ${segments.join('/')}`);
+  }
+
+  // Symlink-aware re-check for anything that already exists on disk. A missing
+  // target (new-file write) is safe: the lexical check above already held, and
+  // comparing it against the *physical* root here would misfire whenever an
+  // ancestor of root is itself a symlink (e.g. darwin /var -> /private/var).
+  let real: string;
+  try {
+    real = fs.realpathSync(resolved);
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err;
+    // A dangling symlink ENOENTs on realpath exactly like a missing file, but a
+    // subsequent write would FOLLOW the link outside the root. lstat (which
+    // does not follow links) distinguishes the two cases.
+    let st: fs.Stats | undefined;
+    try {
+      st = fs.lstatSync(resolved);
+    } catch (lstatErr: any) {
+      if (lstatErr?.code !== 'ENOENT') throw lstatErr;
+      // Genuinely absent — the lexical check above held, safe.
+      return resolved;
+    }
+    if (st.isSymbolicLink()) {
+      throw new Error('Path escapes sandbox root via dangling symlink');
+    }
+    return resolved;
+  }
+  // Target exists, so every ancestor of root exists too: this cannot ENOENT.
+  const realRoot = fs.realpathSync(resolvedRoot);
+  if (!contained(real, realRoot)) {
+    throw new Error(`Path escapes sandbox root via symlink: ${segments.join('/')}`);
+  }
+  return real;
+}
+
+/**
+ * Restricts a renderer-supplied identifier (chatId, site name, ...) to a
+ * single safe path segment: 1-120 chars of [A-Za-z0-9._-] with no '..'.
+ */
+export function assertSafeSegment(segment: string, label = 'identifier'): string {
+  if (
+    typeof segment !== 'string' ||
+    segment.length < 1 ||
+    segment.length > 120 ||
+    segment.includes('..') ||
+    !/^[A-Za-z0-9._-]+$/.test(segment)
+  ) {
+    throw new Error(`Unsafe ${label}: ${String(segment).slice(0, 40)}`);
+  }
+  return segment;
+}

--- a/main/main.ts
+++ b/main/main.ts
@@ -59,6 +59,36 @@ console.log('[Startup] Node version:', process.version);
 console.log('[Startup] App path:', app.getAppPath());
 console.log('[Startup] User data:', app.getPath('userData'));
 
+// ── Global quit/crash state ─────────────────────────────────────────
+// Declared before the fatal-error net below so an early-startup crash
+// can never hit a temporal dead zone while reading them.
+let isAppQuitting = false;
+let rendererCrashCount = 0;
+
+// ── Global Fatal-Error Net ──────────────────────────────────────────
+// Prevents silent main-process death: log, keep a breadcrumb, and stay alive
+// for recoverable errors. A crash during window creation still relaunches.
+process.on('uncaughtException', (err) => {
+  console.error('[Fatal] Uncaught exception in main process:', err);
+  try {
+    // Persist the breadcrumb so crashes leave evidence on disk.
+    const logsDir = path.join(app.getPath('userData'), 'crash-logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(logsDir, `main-${Date.now()}.log`),
+      `${new Date().toISOString()}\n${err?.stack || String(err)}\n`
+    );
+  } catch { /* best effort */ }
+  if (!isAppQuitting && app.isReady() && !BrowserWindow.getAllWindows().length) {
+    // No window to recover into — relaunch rather than vanish.
+    app.relaunch();
+    app.exit(1);
+  }
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('[Fatal] Unhandled rejection in main process:', reason);
+});
+
 // ── Check for Auto-Start Mode ───────────────────────────────────────
 const isAutoStartMode = process.argv.includes('--auto-start');
 console.log('[Startup] Auto-start mode:', isAutoStartMode);
@@ -358,8 +388,21 @@ function createWindow(): void {
     });
   }
 
-  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+  // Track load failures so we can retry instead of leaving a blank window.
+  let loadRetryCount = 0;
+  const win = mainWindow;
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (errorCode === -3) return; // ERR_ABORTED: interrupted navigation, not a real failure
     console.error(`[Window] ❌ did-fail-load: ${errorCode} (${errorDescription}) for URL: ${validatedURL}`);
+    if (loadRetryCount < 2 && !isAppQuitting && isMainFrame) {
+      loadRetryCount += 1;
+      console.warn(`[Window] Retrying load (attempt ${loadRetryCount}/2)...`);
+      setTimeout(() => {
+        try {
+          if (!win.isDestroyed()) win.webContents.reload();
+        } catch { /* window may be gone */ }
+      }, 1000);
+    }
   });
 
   mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
@@ -370,6 +413,24 @@ function createWindow(): void {
 
   mainWindow.webContents.on('render-process-gone', (event, details) => {
     console.error('[Window] ❌ Renderer process gone:', details);
+    // Auto-recover from renderer crashes (grey screen prevention): reload a few
+    // times before giving up and relaunching the whole app.
+    if (isAppQuitting) return;
+    const reason = details?.reason || '';
+    if (reason === 'clean-exit') return;
+    rendererCrashCount += 1;
+    if (rendererCrashCount <= 3) {
+      console.warn(`[Window] Auto-reloading after renderer crash (${rendererCrashCount}/3)...`);
+      setTimeout(() => {
+        try {
+          if (!win.isDestroyed()) win.webContents.reload();
+        } catch { /* window gone */ }
+      }, 500);
+    } else {
+      console.error('[Window] Too many renderer crashes — relaunching app.');
+      app.relaunch();
+      app.exit(1);
+    }
   });
 
   mainWindow.webContents.on('unresponsive', () => {
@@ -378,6 +439,7 @@ function createWindow(): void {
 
   mainWindow.webContents.on('did-finish-load', () => {
     console.log('[Window] Page finished loading');
+    rendererCrashCount = 0;
   });
 
   // Open external links securely in default browser
@@ -689,7 +751,7 @@ Your goal is to be the ultimate workplace companion.
 
   // Custom protocol for local sites
   protocol.handle('everfern-site', async (request) => {
-// ... existing site logic ...
+    // Accepted intra-user exposure (single-user threat model): any local frame may read any chatId's site.
     const url = new URL(request.url);
     const chatId = url.hostname;
     let filePath = url.pathname;
@@ -711,8 +773,8 @@ Your goal is to be the ultimate workplace companion.
     const sitesRoot = path.join(os.homedir(), '.everfern', 'sites');
     const artifactsRoot = path.join(os.homedir(), '.everfern', 'artifacts');
 
-    const isUnderSites = absPath.startsWith(sitesRoot);
-    const isUnderArtifacts = absPath.startsWith(artifactsRoot);
+    const isUnderSites = absPath.startsWith(sitesRoot.endsWith(path.sep) ? sitesRoot : sitesRoot + path.sep);
+    const isUnderArtifacts = absPath.startsWith(artifactsRoot.endsWith(path.sep) ? artifactsRoot : artifactsRoot + path.sep);
 
     if (!isUnderSites && !isUnderArtifacts) {
       return new Response('Forbidden', { status: 403 });
@@ -827,68 +889,88 @@ app.on('activate', () => {
 });
 
 // ── Graceful shutdown & cleanup on quit ──────────────────────────────
-let isAppQuitting = false;
+// NOTE: isAppQuitting / rendererCrashCount live at the top of this file.
+
+// Run one shutdown step with a hard timeout so a hung socket/DB/MCP call can
+// never block quitting. Returns 'timeout' instead of throwing.
+async function withShutdownTimeout(name: string, step: () => any, ms = 3000): Promise<void> {
+  try {
+    await Promise.race([
+      Promise.resolve(step()).catch((err) => {
+        console.error(`[Shutdown] ${name} failed:`, err);
+      }),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), ms)),
+    ]).then((result) => {
+      if (result === 'timeout') console.warn(`[Shutdown] ${name} timed out after ${ms}ms — continuing.`);
+    });
+  } catch (err) {
+    console.error(`[Shutdown] ${name} unexpected failure:`, err);
+  }
+}
+
 app.on('before-quit', async (event) => {
   if (isAppQuitting) return;
   event.preventDefault();
   isAppQuitting = true;
   console.log('[Shutdown] Graceful app shutdown initiated...');
 
-  // Stop Agent Gateway Control Plane
+  // Hard failsafe: no matter what happens below, the app WILL exit.
+  // NOTE: this 8s budget intentionally overrides individual step timeouts (5×3s+2×4s=23s worst case).
+  const forceExitTimer = setTimeout(() => {
+    console.error('[Shutdown] Cleanup exceeded budget — forcing exit.');
+    app.exit(0);
+  }, 8000);
+  // Never keep the process alive just for this timer.
+  forceExitTimer.unref?.();
+
+  // Release OS-global hooks first so hotkeys never outlive the process.
   try {
+    globalShortcut.unregisterAll();
+  } catch (shortcutErr) {
+    console.error('[Shutdown] Failed to unregister global shortcuts:', shortcutErr);
+  }
+
+  // Terminate the local STT child (app.exit below skips will-quit listeners).
+  try {
+    const { shutdownLocalStt } = require('./ipc/system/ollama-audio-handlers');
+    shutdownLocalStt();
+  } catch { /* module may not be loaded */ }
+
+  // Stop Agent Gateway Control Plane
+  await withShutdownTimeout('Agent Gateway', () => {
     const { agentGatewayServer } = require('./agent/gateway');
     agentGatewayServer.stop();
-  } catch (gatewayErr) {
-    console.error('[Shutdown] Failed to stop Agent Gateway:', gatewayErr);
-  }
+  });
 
   // Clean up MessageHandler
-  await shutdownBotMessageHandler();
+  await withShutdownTimeout('MessageHandler', () => shutdownBotMessageHandler());
 
   // Stop integration services
-  try {
-    console.log('[App] Stopping integration services...');
-    await integrationService.stop();
-    console.log('[App] Integration services stopped successfully');
-  } catch (error) {
-    console.error('[App] Error stopping integration services:', error);
-  }
+  console.log('[App] Stopping integration services...');
+  await withShutdownTimeout('Integration services', () => integrationService.stop());
+  console.log('[App] Integration services stopped successfully');
 
   // Stop extension bridge server
-  try {
-    console.log('[App] Stopping extension bridge server...');
-    bridgeServer.stop();
-    console.log('[App] Extension bridge server stopped successfully');
-  } catch (error) {
-    console.error('[App] Error stopping extension bridge server:', error);
-  }
+  console.log('[App] Stopping extension bridge server...');
+  await withShutdownTimeout('Extension bridge', () => bridgeServer.stop());
 
   // Shutdown background processor
-  try {
-    console.log('[App] Shutting down background processor...');
-    await backgroundProcessor.shutdown();
-    console.log('[App] Background processor shutdown complete');
-  } catch (error) {
-    console.error('[App] Error shutting down background processor:', error);
-  }
+  console.log('[App] Shutting down background processor...');
+  await withShutdownTimeout('Background processor', () => backgroundProcessor.shutdown());
 
   // Shutdown MCP tools
-  try {
-    console.log('[App] Shutting down MCP tools...');
-    await shutdownMCPTools();
-    console.log('[App] MCP tools shutdown complete');
-  } catch (error) {
-    console.error('[App] Error shutting down MCP tools:', error);
-  }
+  console.log('[App] Shutting down MCP tools...');
+  await withShutdownTimeout('MCP tools', () => shutdownMCPTools(), 4000);
 
   // Close database connection cleanly
-  try {
-    console.log('[App] Closing database connection...');
-    await closeDb();
-    console.log('[App] Database connection closed successfully');
-  } catch (error) {
-    console.error('[App] Error closing database connection:', error);
-  }
+  console.log('[App] Closing database connection...');
+  await withShutdownTimeout('Database', () => closeDb(), 4000);
+
+  // Close chat vector store
+  await withShutdownTimeout('Chat vector DB', () => {
+    const { closeChatVectorDb } = require('./store/chat-vectors');
+    closeChatVectorDb();
+  }, 3000);
 
   // Clean up system tray
   try {
@@ -898,6 +980,7 @@ app.on('before-quit', async (event) => {
   }
 
   console.log('[Shutdown] Cleanup finished, exiting process.');
+  clearTimeout(forceExitTimer);
   app.exit(0);
 });
 
@@ -1003,24 +1086,51 @@ ipcMain.handle('audio:play-sound', async (_event, soundPath: string) => {
     const { execFile } = require('child_process');
     const os = require('os');
 
-    // Construct full path to sound file
-    const soundFilePath = path.join(__dirname, '../../public/sounds', soundPath);
-
-    console.log(`[Audio] Playing sound: ${soundFilePath}`);
-
-    if (!fs.existsSync(soundFilePath)) {
-      console.warn(`[Audio] Sound file not found: ${soundFilePath}`);
+    // MP-SEC-01: never join raw renderer input into a path — only accept a
+    // validated bare filename, resolved against our own sounds directories.
+    const safeName = path.basename(soundPath || '');
+    if (safeName === '.' || safeName === '..' || !/^[A-Za-z0-9._-]{1,64}$/.test(safeName)) {
+      console.warn(`[Audio] Rejected invalid sound name`);
       return false;
     }
+
+    // MAC-10: public/sounds ships as extraResources (outside the asar) in
+    // packaged builds; probe candidate roots and use the first containing the file.
+    const soundDirs = [
+      process.resourcesPath ? path.join(process.resourcesPath, 'public', 'sounds') : '',
+      path.join(__dirname, '../../public/sounds'),
+      path.join(app.getAppPath(), 'public', 'sounds')
+    ].filter(Boolean);
+
+    let soundFilePath = '';
+    let soundFound = false;
+    for (const dir of soundDirs) {
+      const candidate = path.join(dir, safeName);
+      if (fs.existsSync(candidate)) {
+        soundFilePath = candidate;
+        soundFound = true;
+        break;
+      }
+    }
+
+    if (!soundFound) {
+      console.warn(`[Audio] Sound file not found: ${safeName}`);
+      return false;
+    }
+
+    console.log(`[Audio] Playing sound: ${soundFilePath}`);
 
     // Use platform-specific audio player
     const platform = os.platform();
 
     if (platform === 'win32') {
-      // Windows: Use PowerShell to play sound
+      // Windows: Use PowerShell to play sound.
+      // Safe: soundFilePath is a validated basename resolved inside our own
+      // dirs, but install/user dirs may still contain apostrophes — PowerShell
+      // single-quote escaping doubles them ('').
       execFile('powershell.exe', [
         '-Command',
-        `(New-Object System.Media.SoundPlayer '${soundFilePath}').PlaySync()`
+        `(New-Object System.Media.SoundPlayer '${soundFilePath.replace(/'/g, "''")}').PlaySync()`
       ], { maxBuffer: 10 * 1024 * 1024 });
     } else if (platform === 'darwin') {
       // macOS: Use afplay command

--- a/main/store/__tests__/chat-persistence-fix.test.ts
+++ b/main/store/__tests__/chat-persistence-fix.test.ts
@@ -6,12 +6,12 @@
  * delete previous messages from the database.
  *
  * Bug: Previous behavior would delete all messages not in the current save
- * Fix: Only delete messages if isFullSave is explicitly NOT false
+ * Fix: Only delete messages if isFullSave is explicitly true
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ChatHistoryStore } from '../history';
-import { databaseService } from '../database-service';
+import { dbOps } from '../../lib/db';
 
 describe('Chat Message Persistence on Restart', () => {
   let historyStore: ChatHistoryStore;
@@ -25,8 +25,8 @@ describe('Chat Message Persistence on Restart', () => {
   afterEach(async () => {
     // Cleanup
     try {
-      await databaseService.run('DELETE FROM messages WHERE conversation_id = ?', [testConvId]);
-      await databaseService.run('DELETE FROM conversations WHERE id = ?', [testConvId]);
+      await dbOps.run('DELETE FROM messages WHERE conversation_id = ?', [testConvId]);
+      await dbOps.run('DELETE FROM conversations WHERE id = ?', [testConvId]);
     } catch (err) {
       // Ignore cleanup errors
     }
@@ -106,15 +106,16 @@ describe('Chat Message Persistence on Restart', () => {
   });
 
   /**
-   * Test 2: Full saves SHOULD delete unspecified messages
+   * Test 2: Only explicit full saves SHOULD delete unspecified messages
    *
    * Scenario:
    * 1. Save conversation with 3 messages
-   * 2. Do a full save with only 2 messages (isFullSave: true or undefined)
-   * 3. Load conversation
-   * Expected: Only 2 messages should exist (the 3rd was deleted as expected)
+   * 2. Do a save with only 2 messages and NO isFullSave flag
+   * Expected: All 3 messages survive (absence of the flag must NOT trigger cleanup)
+   * 3. Do an explicit full save (isFullSave: true) with only 2 messages
+   * Expected: Only 2 messages exist (msg-3 deleted as expected)
    */
-  it('should delete messages not in full save (isFullSave: true or undefined)', async () => {
+  it('should delete messages not in save only when isFullSave is explicitly true', async () => {
     // Step 1: Initial save with 3 messages
     const initialConversation = {
       id: testConvId,
@@ -151,7 +152,38 @@ describe('Chat Message Persistence on Restart', () => {
     let loaded = await historyStore.load(testConvId);
     expect(loaded?.messages.length).toBe(3);
 
-    // Step 2: Full save with only 2 messages (isFullSave defaults to true)
+    // Step 2: Save with only 2 messages and NO isFullSave flag
+    const unflaggedUpdate = {
+      id: testConvId,
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user' as const,
+          content: 'Message 1',
+          createdAt: new Date().toISOString()
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant' as const,
+          content: 'Message 2 [edited]',
+          createdAt: new Date().toISOString()
+        }
+      ],
+      // isFullSave is intentionally omitted - absence must NOT trigger cleanup
+      updatedAt: new Date().toISOString()
+    };
+
+    const saveResult2 = await historyStore.save(unflaggedUpdate as any);
+    expect(saveResult2.success).toBe(true);
+
+    // Step 3: Load conversation - verify ALL messages still exist
+    loaded = await historyStore.load(testConvId);
+    expect(loaded?.messages.length).toBe(3).withContext(
+      'Save without explicit isFullSave flag should NOT delete msg-3'
+    );
+    expect(loaded?.messages.map(m => m.id)).toEqual(['msg-1', 'msg-2', 'msg-3']);
+
+    // Step 4: Explicit full save (isFullSave: true) with only 2 messages
     const fullUpdate = {
       id: testConvId,
       messages: [
@@ -168,17 +200,17 @@ describe('Chat Message Persistence on Restart', () => {
           createdAt: new Date().toISOString()
         }
       ],
-      // isFullSave is NOT set to false, so cleanup should happen
+      isFullSave: true, // Explicit full snapshot - cleanup SHOULD happen
       updatedAt: new Date().toISOString()
     };
 
-    const saveResult2 = await historyStore.save(fullUpdate as any);
-    expect(saveResult2.success).toBe(true);
+    const saveResult3 = await historyStore.save(fullUpdate as any);
+    expect(saveResult3.success).toBe(true);
 
-    // Step 3: Load conversation - verify msg-3 was deleted
+    // Step 5: Load conversation - verify msg-3 was deleted
     loaded = await historyStore.load(testConvId);
     expect(loaded?.messages.length).toBe(2).withContext(
-      'Full save should delete msg-3 which was not included'
+      'Explicit isFullSave:true should delete msg-3 which was not included'
     );
     expect(loaded?.messages.map(m => m.id)).toEqual(['msg-1', 'msg-2']);
   });

--- a/main/store/artifacts.ts
+++ b/main/store/artifacts.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { assertSafeSegment, resolveWithin } from '../lib/path-guard';
+
+// MP-SEC-02: sandbox root every global artifact path must stay within.
+const ARTIFACTS_DIR = path.join(os.homedir(), '.everfern', 'artifacts');
 
 export interface ArtifactMeta {
   id: string;
@@ -30,7 +34,7 @@ async function exists(p: string): Promise<boolean> {
  * Scans ~/.everfern/artifacts/ and projectPath/.everfern/artifacts/ if provided.
  */
 export async function listArtifacts(chatId?: string, projectPath?: string): Promise<ArtifactMeta[]> {
-  const globalArtifactsDir = path.join(os.homedir(), '.everfern', 'artifacts');
+  const globalArtifactsDir = ARTIFACTS_DIR;
   const results: ArtifactMeta[] = [];
 
   // 1. Scan global artifacts
@@ -38,7 +42,7 @@ export async function listArtifacts(chatId?: string, projectPath?: string): Prom
     let dirsToScan: string[] = [];
     try {
       if (chatId) {
-        dirsToScan = [chatId];
+        dirsToScan = [assertSafeSegment(chatId, 'chat id')];
       } else {
         const entries = await fs.promises.readdir(globalArtifactsDir);
         for (const f of entries) {
@@ -122,9 +126,9 @@ export async function readArtifact(chatId: string, filename: string, projectPath
   let filepath: string;
   
   if (projectPath && chatId === 'project') {
-    filepath = path.join(projectPath, '.everfern', 'artifacts', filename);
+    filepath = resolveWithin(path.join(projectPath, '.everfern', 'artifacts'), filename);
   } else {
-    filepath = path.join(os.homedir(), '.everfern', 'artifacts', chatId, filename);
+    filepath = resolveWithin(ARTIFACTS_DIR, assertSafeSegment(chatId, 'chat id'), filename);
   }
 
   if (await exists(filepath)) {
@@ -151,15 +155,15 @@ export async function writeArtifact(chatId: string, filename: string, content: s
   try {
     let dir: string;
     if (projectPath) {
-      dir = path.join(projectPath, '.everfern', 'artifacts');
+      dir = resolveWithin(path.join(projectPath, '.everfern', 'artifacts'));
     } else {
-      dir = path.join(os.homedir(), '.everfern', 'artifacts', chatId);
+      dir = resolveWithin(ARTIFACTS_DIR, assertSafeSegment(chatId, 'chat id'));
     }
     
     if (!(await exists(dir))) {
       await fs.promises.mkdir(dir, { recursive: true });
     }
-    await fs.promises.writeFile(path.join(dir, filename), content, 'utf-8');
+    await fs.promises.writeFile(resolveWithin(dir, filename), content, 'utf-8');
     return { success: true };
   } catch (e) {
     return { success: false, error: String(e) };
@@ -173,9 +177,9 @@ export async function deleteArtifact(chatId: string, filename: string, projectPa
   try {
     let p: string;
     if (projectPath && chatId === 'project') {
-      p = path.join(projectPath, '.everfern', 'artifacts', filename);
+      p = resolveWithin(path.join(projectPath, '.everfern', 'artifacts'), filename);
     } else {
-      p = path.join(os.homedir(), '.everfern', 'artifacts', chatId, filename);
+      p = resolveWithin(ARTIFACTS_DIR, assertSafeSegment(chatId, 'chat id'), filename);
     }
     
     if (await exists(p)) {
@@ -192,20 +196,22 @@ export async function deleteArtifact(chatId: string, filename: string, projectPa
  * This prevents corruption if the write operation is interrupted.
  */
 export async function writeArtifactAtomic(chatId: string, filename: string, content: string, projectPath?: string): Promise<{ success: boolean; error?: string }> {
+  let dir: string;
+  let filePath: string;
+  let tempPath: string | undefined;
   try {
-    let dir: string;
     if (projectPath) {
-      dir = path.join(projectPath, '.everfern', 'artifacts');
+      dir = resolveWithin(path.join(projectPath, '.everfern', 'artifacts'));
     } else {
-      dir = path.join(os.homedir(), '.everfern', 'artifacts', chatId);
+      dir = resolveWithin(ARTIFACTS_DIR, assertSafeSegment(chatId, 'chat id'));
     }
     
     if (!(await exists(dir))) {
       await fs.promises.mkdir(dir, { recursive: true });
     }
 
-    const filePath = path.join(dir, filename);
-    const tempPath = `${filePath}.tmp`;
+    filePath = resolveWithin(dir, filename);
+    tempPath = `${filePath}.tmp`;
 
     // Write to temporary file
     await fs.promises.writeFile(tempPath, content, 'utf-8');
@@ -215,17 +221,10 @@ export async function writeArtifactAtomic(chatId: string, filename: string, cont
 
     return { success: true };
   } catch (e) {
-    // Clean up temporary file if it exists
+    // Clean up temporary file if it exists (reuse the guarded path captured
+    // above; never re-join raw chatId/projectPath here)
     try {
-      let dir: string;
-      if (projectPath) {
-        dir = path.join(projectPath, '.everfern', 'artifacts');
-      } else {
-        dir = path.join(os.homedir(), '.everfern', 'artifacts', chatId);
-      }
-      const filePath = path.join(dir, filename);
-      const tempPath = `${filePath}.tmp`;
-      if (await exists(tempPath)) {
+      if (tempPath && (await exists(tempPath))) {
         await fs.promises.unlink(tempPath);
       }
     } catch {
@@ -242,9 +241,9 @@ export async function updateArtifactTimestamp(chatId: string, filename: string, 
   try {
     let filePath: string;
     if (projectPath && chatId === 'project') {
-      filePath = path.join(projectPath, '.everfern', 'artifacts', filename);
+      filePath = resolveWithin(path.join(projectPath, '.everfern', 'artifacts'), filename);
     } else {
-      filePath = path.join(os.homedir(), '.everfern', 'artifacts', chatId, filename);
+      filePath = resolveWithin(ARTIFACTS_DIR, assertSafeSegment(chatId, 'chat id'), filename);
     }
     
     if (!(await exists(filePath))) {

--- a/main/store/chat-vectors.ts
+++ b/main/store/chat-vectors.ts
@@ -14,7 +14,9 @@ import fs from 'fs';
 import os from 'os';
 
 let instance: sqlite3.Database | null = null;
+let instancePromise: Promise<sqlite3.Database> | null = null;
 let isInitialized = false;
+let isClosing = false;
 
 export interface VectorMessage {
   id: string;
@@ -50,29 +52,41 @@ function ensureDir(): void {
 
 let writeQueue: Array<() => void> = [];
 let isWriteInProgress = false;
+let isNextScheduled = false;
 
 function queueWrite(fn: () => void): void {
   writeQueue.push(fn);
   processQueue();
 }
 
+// Release the write slot only once the write's callback/completion has fired,
+// then schedule the next queued item.
+function finishWrite(): void {
+  isWriteInProgress = false;
+  scheduleNext();
+}
+
+function scheduleNext(): void {
+  if (isNextScheduled || isWriteInProgress || writeQueue.length === 0 || !instance) return;
+  isNextScheduled = true;
+  setTimeout(() => {
+    isNextScheduled = false;
+    processQueue();
+  }, 10);
+}
+
 function processQueue(): void {
   if (isWriteInProgress || writeQueue.length === 0 || !instance) return;
 
-  isWriteInProgress = true;
   const next = writeQueue.shift();
-  if (next) {
-    try {
-      next();
-    } catch (err) {
-      log('Queue write error:', err);
-    }
-  }
-  isWriteInProgress = false;
+  if (!next) return;
 
-  // Process next in queue
-  if (writeQueue.length > 0) {
-    setTimeout(processQueue, 10);
+  isWriteInProgress = true;
+  try {
+    next();
+  } catch (err) {
+    log('Queue write error:', err);
+    finishWrite();
   }
 }
 
@@ -132,11 +146,17 @@ export async function initChatVectorDb(): Promise<sqlite3.Database> {
   });
 }
 
-export async function getChatVectorDb(): Promise<sqlite3.Database> {
-  if (!instance) {
-    await initChatVectorDb();
+export function getChatVectorDb(): Promise<sqlite3.Database> {
+  if (isClosing) {
+    return Promise.reject(new Error('Chat vector DB is closing'));
   }
-  return instance!;
+  if (!instancePromise) {
+    instancePromise = initChatVectorDb().catch((err) => {
+      instancePromise = null;
+      throw err;
+    });
+  }
+  return instancePromise!;
 }
 
 export async function embedAndStoreMessage(
@@ -171,14 +191,12 @@ export async function embedAndStoreMessage(
                 log('Message stored successfully');
                 res();
               }
-              isWriteInProgress = false;
-              processQueue();
+              finishWrite();
             }
           );
         } catch (err: any) {
           log('Queue write error:', err.message);
-          isWriteInProgress = false;
-          processQueue();
+          finishWrite();
           rej(err);
         }
       });
@@ -303,8 +321,7 @@ export async function deleteChatVectors(chatId: string): Promise<void> {
             log('Deleted vectors for chat:', chatId);
             res();
           }
-          isWriteInProgress = false;
-          processQueue();
+          finishWrite();
         });
       });
     });
@@ -316,20 +333,47 @@ export async function deleteChatVectors(chatId: string): Promise<void> {
 export async function closeChatVectorDb(): Promise<void> {
   log('closeChatVectorDb');
 
-  if (instance) {
-    return new Promise((res, rej) => {
-      instance!.close((e) => {
-        if (e) {
-          log('closeChatVectorDb ERROR:', e.message);
-          rej(e);
-        } else {
-          log('Database closed');
-          instance = null;
-          isInitialized = false;
-          res();
-        }
+  isClosing = true;
+
+  try {
+    if (instance) {
+      await new Promise<void>((res, rej) => {
+        instance!.close((e) => {
+          if (e) {
+            log('closeChatVectorDb ERROR:', e.message);
+            rej(e);
+          } else {
+            log('Database closed');
+            res();
+          }
+        });
       });
-    });
+      instance = null;
+      instancePromise = null;
+      isInitialized = false;
+    } else if (instancePromise) {
+      try {
+        const db = await instancePromise;
+        await new Promise<void>((res, rej) => {
+          db.close((e) => {
+            if (e) {
+              log('closeChatVectorDb ERROR:', e.message);
+              rej(e);
+            } else {
+              log('Database closed (in-flight init)');
+              res();
+            }
+          });
+        });
+        instance = null;
+        instancePromise = null;
+        isInitialized = false;
+      } catch (err: any) {
+        log('closeChatVectorDb in-flight init error:', err?.message);
+      }
+    }
+  } finally {
+    isClosing = false;
   }
 }
 

--- a/main/store/history.ts
+++ b/main/store/history.ts
@@ -15,6 +15,17 @@ import { getSystemEmbeddingConfig, getEmbeddingModel } from '../lib/embeddings';
 const LEGACY_CONVERSATIONS_DIR = path.join(os.homedir(), '.everfern', 'store', 'conversations');
 const LEGACY_TIMELINE_DIR = path.join(os.homedir(), '.everfern', 'store', 'timeline');
 
+// Defensive parse: one corrupted column must never null out a whole conversation.
+export function parseJsonField<T>(raw: unknown, fallback: T, label: string): T {
+  try {
+    if (raw == null) return fallback;
+    return JSON.parse(String(raw)) as T;
+  } catch (err) {
+    console.warn(`[History] Corrupt ${label} field ignored:`, err instanceof Error ? err.message : err);
+    return fallback;
+  }
+}
+
 export class ChatHistoryStore {
   private migrated = false;
   private saveMutex = false;
@@ -330,7 +341,7 @@ export class ChatHistoryStore {
       const msgRows = await dbOps.all('SELECT * FROM messages WHERE conversation_id = ? ORDER BY order_index ASC, created_at ASC', [id]);
 
       const messages: ChatMessage[] = msgRows.map(row => {
-        let toolCalls = row.tool_calls ? JSON.parse(row.tool_calls) : undefined;
+        let toolCalls = parseJsonField<any[] | undefined>(row.tool_calls, undefined, 'tool_calls');
         if (Array.isArray(toolCalls)) {
           toolCalls.sort((a: any, b: any) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0));
         }
@@ -341,12 +352,12 @@ export class ChatHistoryStore {
           thought: row.thought,
           reasoning_content: row.reasoning_content || row.thought,
           toolCalls,
-          missionTimeline: row.mission_timeline ? JSON.parse(row.mission_timeline) : undefined,
+          missionTimeline: parseJsonField<any>(row.mission_timeline, undefined, 'mission_timeline'),
           hasTimeline: !!row.has_timeline,
           orderIndex: row.order_index ?? 0,
           thinkingDuration: row.thinking_duration ?? undefined,
           stopped: row.stopped === 1 || row.stopped === true,
-          attachments: row.attachments ? JSON.parse(row.attachments) : undefined,
+          attachments: parseJsonField<any[] | undefined>(row.attachments, undefined, 'attachments'),
           createdAt: row.created_at
         };
       });
@@ -472,7 +483,7 @@ export class ChatHistoryStore {
       // Cleanup orphaned/stale messages ONLY if this is a full conversation save
       // (indicated by (conversation as any).isFullSave flag)
       // Chunk deletions into batches of 400 to prevent exceeding SQLITE_MAX_VARIABLE_NUMBER (999)
-      if ((conversation as any).isFullSave !== false && savedIds.length > 0) {
+      if ((conversation as any).isFullSave === true && savedIds.length > 0) {
         const CHUNK_SIZE = 400;
         const allCurrentRows = await dbOps.all(
           'SELECT id FROM messages WHERE conversation_id = ?',
@@ -489,7 +500,7 @@ export class ChatHistoryStore {
             [conversation.id, ...chunk]
           );
         }
-      } else if ((conversation as any).isFullSave !== false) {
+      } else if ((conversation as any).isFullSave === true) {
         await dbOps.run(
           'DELETE FROM messages WHERE conversation_id = ?',
           [conversation.id]

--- a/main/store/memory-manager.ts
+++ b/main/store/memory-manager.ts
@@ -305,16 +305,16 @@ Respond with ONLY new memory entries in Markdown bullet format, or "NO_NEW_MEMOR
 
       // Strip any lines that snuck through containing file paths, artifact locations, or task results
       const PATH_PATTERNS = [
-        /c:\\[^\s]*/gi,           // Windows absolute paths
-        /\.everfern[^\s]*/gi,     // .everfern directory references
-        /artifacts[^\s]*/gi,      // artifact paths
-        /\.html\b/gi,             // HTML file references
-        /\.py\b/gi,               // Python file references
-        /what worked:/gi,         // "What Worked" sections
-        /project architecture:/gi, // "Project Architecture" sections
-        /successfully deliver/gi,  // task result language
-        /report.*generated/gi,    // report generation results
-        /file.*saved/gi,          // file save results
+        /c:\\[^\s]*/i,            // Windows absolute paths
+        /\.everfern[^\s]*/i,      // .everfern directory references
+        /artifacts[^\s]*/i,       // artifact paths
+        /\.html\b/i,              // HTML file references
+        /\.py\b/i,                // Python file references
+        /what worked:/i,          // "What Worked" sections
+        /project architecture:/i, // "Project Architecture" sections
+        /successfully deliver/i,  // task result language
+        /report.*generated/i,     // report generation results
+        /file.*saved/i,           // file save results
       ];
 
       const filteredLines = content.split('\n').filter(line => {

--- a/main/store/plans.ts
+++ b/main/store/plans.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { assertSafeSegment, resolveWithin } from '../lib/path-guard';
 
 const PLAN_BASE = path.join(os.homedir(), '.everfern', 'chat', 'plan');
 
 function planDir(chatId: string): string {
-  return path.join(PLAN_BASE, chatId);
+  return path.join(PLAN_BASE, assertSafeSegment(chatId, 'chat id'));
 }
 
 /**
@@ -29,7 +30,7 @@ async function ensurePlanDir(chatId: string): Promise<void> {
 export async function writePlan(chatId: string, filename: string, content: string): Promise<{ success: boolean; error?: string }> {
   try {
     await ensurePlanDir(chatId);
-    await fs.promises.writeFile(path.join(planDir(chatId), filename), content, 'utf-8');
+    await fs.promises.writeFile(resolveWithin(planDir(chatId), filename), content, 'utf-8');
     return { success: true };
   } catch (e) {
     return { success: false, error: String(e) };
@@ -38,7 +39,7 @@ export async function writePlan(chatId: string, filename: string, content: strin
 
 /** Read a plan file. Returns null if not found. */
 export async function readPlan(chatId: string, filename: string): Promise<string | null> {
-  const p = path.join(planDir(chatId), filename);
+  const p = resolveWithin(planDir(chatId), filename);
   if (!(await exists(p))) return null;
   try {
     return await fs.promises.readFile(p, 'utf-8');
@@ -68,7 +69,7 @@ export async function listPlans(chatId: string): Promise<string[]> {
 /** Delete a single plan file. */
 export async function deletePlan(chatId: string, filename: string): Promise<{ success: boolean }> {
   try {
-    const p = path.join(planDir(chatId), filename);
+    const p = resolveWithin(planDir(chatId), filename);
     if (await exists(p)) await fs.promises.unlink(p);
     return { success: true };
   } catch {

--- a/main/store/sites.ts
+++ b/main/store/sites.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { assertSafeSegment, resolveWithin } from '../lib/path-guard';
 
 export interface SiteMeta {
   id: string; // filename or foldername
@@ -35,7 +36,7 @@ export async function listSites(chatId?: string): Promise<SiteMeta[]> {
   try {
     let dirs: string[] = [];
     if (chatId) {
-      dirs = [chatId];
+      dirs = [assertSafeSegment(chatId, 'site name')];
     } else {
       const entries = await fs.promises.readdir(SITES_DIR);
       for (const f of entries) {
@@ -75,7 +76,7 @@ export async function listSites(chatId?: string): Promise<SiteMeta[]> {
  * Reads a site file (usually index.html).
  */
 export async function readSiteFile(chatId: string, filename: string): Promise<string | null> {
-  const p = path.join(SITES_DIR, chatId, filename);
+  const p = resolveWithin(SITES_DIR, assertSafeSegment(chatId, 'site name'), filename);
   if (!(await exists(p))) return null;
   try {
     return await fs.promises.readFile(p, 'utf-8');
@@ -89,9 +90,9 @@ export async function readSiteFile(chatId: string, filename: string): Promise<st
  */
 export async function writeSiteFile(chatId: string, filename: string, content: string): Promise<{ success: boolean; error?: string }> {
   try {
-    const dir = path.join(SITES_DIR, chatId);
+    const dir = resolveWithin(SITES_DIR, assertSafeSegment(chatId, 'site name'));
     if (!(await exists(dir))) await fs.promises.mkdir(dir, { recursive: true });
-    await fs.promises.writeFile(path.join(dir, filename), content, 'utf-8');
+    await fs.promises.writeFile(resolveWithin(dir, filename), content, 'utf-8');
     return { success: true };
   } catch (e) {
     return { success: false, error: String(e) };
@@ -103,10 +104,15 @@ export async function writeSiteFile(chatId: string, filename: string, content: s
  */
 export async function deleteSite(chatId: string, filename?: string): Promise<{ success: boolean }> {
   try {
-    const p = filename ? path.join(SITES_DIR, chatId, filename) : path.join(SITES_DIR, chatId);
+    const site = assertSafeSegment(chatId, 'site name');
+    const p = filename ? resolveWithin(SITES_DIR, site, filename) : resolveWithin(SITES_DIR, site);
     if (await exists(p)) {
       const stats = await fs.promises.stat(p);
       if (stats.isDirectory()) {
+        // MP-SEC-02: only direct children of the sites root may be recursively removed
+        if (fs.realpathSync(path.dirname(p)) !== fs.realpathSync(SITES_DIR)) {
+          return { success: false };
+        }
         await fs.promises.rm(p, { recursive: true, force: true });
       } else {
         await fs.promises.unlink(p);

--- a/main/store/tool-approvals.ts
+++ b/main/store/tool-approvals.ts
@@ -19,6 +19,63 @@ export interface ToolApprovalPolicy {
 
 const POLICIES_FILE_PATH = path.join(os.homedir(), '.everfern', 'tool-approvals.json');
 
+/**
+ * MP-SEC-08 Fix: Shell metacharacter screen for safe-prefix auto-approval.
+ * Scans the full command with quote-state tracking and reports whether any
+ * chaining/substitution/redirection metacharacter (; & | ` $ ( ) < > or
+ * newline/CR) appears outside single/double quotes. A raw startsWith() alone
+ * would wrongly auto-approve "ls; rm -rf ~" under the 'ls' prefix.
+ *
+ * Single source of truth: pi-tools' WIN_AUTO_LOCAL_HEADS gate imports this so
+ * auto-local execution and safe-prefix approval share one scanner.
+ */
+export function hasUnquotedMetacharacters(cmd: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+
+  for (const ch of cmd) {
+    if (inSingle) {
+      // Inside single quotes everything is literal until the closing quote.
+      if (ch === "'") inSingle = false;
+      continue;
+    }
+
+    if (inDouble) {
+      if (ch === '"') {
+        inDouble = false; // Closing double quote ends the quoted span.
+      } else if (ch === '`' || ch === '$') {
+        // Bash still performs `...` / $(...) substitution inside double
+        // quotes, so treat those as unquoted (fail closed).
+        return true;
+      }
+      continue;
+    }
+
+    // Outside quotes: a quote character opens a quoted span.
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+
+    // Outside quotes: any chain/substitution/redirection metacharacter
+    // (< > write files) disqualifies the command from safe-prefix
+    // auto-approval. \r is screened like \n (CRLF line-splitting tricks).
+    if (
+      ch === ';' || ch === '&' || ch === '|' || ch === '`' ||
+      ch === '$' || ch === '(' || ch === ')' || ch === '\n' ||
+      ch === '<' || ch === '>' || ch === '\r'
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export class ToolApprovalStore {
   private policies: ToolApprovalPolicy[] = [];
   private filePath: string;
@@ -47,7 +104,15 @@ export class ToolApprovalStore {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    fs.writeFileSync(this.filePath, JSON.stringify(this.policies, null, 2), 'utf-8');
+    fs.writeFileSync(
+      this.filePath,
+      // MP-CORR-22 Fix: session-scoped policies (conversationId set) are
+      // in-memory-only by design (Issue #15). Filter at this single choke
+      // point so every persistence path (add/update/delete/clear) writes
+      // only global policies and a reload never resurrects session approvals.
+      JSON.stringify(this.policies.filter(p => !p.conversationId), null, 2),
+      'utf-8'
+    );
   }
 
   /**
@@ -93,9 +158,16 @@ export class ToolApprovalStore {
         'git status', 'git diff', 'git log', 'git branch', 'git show',
         'ls', 'dir', 'pwd', 'whoami', 'date',
         'node -v', 'npm -v', 'pnpm -v', 'yarn -v', 'python --version', 'git --version',
-        'npx tsc --noEmit', 'echo '
+        'npx tsc --noEmit', 'echo'
       ];
-      if (safePrefixes.some(sp => cmd === sp || cmd.startsWith(sp))) {
+      // MP-SEC-08 Fix: require the WHOLE command to be free of unquoted
+      // metacharacters before trusting a prefix match ("ls; rm -rf ~" must
+      // not ride the 'ls' prefix). Suspect commands fall through to the
+      // explicit policy check / HITL approval below.
+      // Word-boundary fix: match the head as an exact token only, so 'ls'
+      // cannot approve 'lsassdump'.
+      const matchesSafePrefix = safePrefixes.some(sp => cmd === sp || cmd.startsWith(sp + ' '));
+      if (matchesSafePrefix && !hasUnquotedMetacharacters(cmd)) {
         return true;
       }
     }

--- a/main/updater.ts
+++ b/main/updater.ts
@@ -10,6 +10,27 @@ export const updateStatus = {
   errorMsg: null as string | null
 };
 
+// Resolve a live window at send time. The window captured at initialization can be
+// destroyed and recreated (e.g. macOS activate path), so always re-resolve.
+function getMainWindow(): BrowserWindow | null {
+  const globalAny = global as any;
+  const candidate: BrowserWindow | undefined = globalAny.mainWindow;
+  if (candidate && !candidate.isDestroyed()) return candidate;
+  const first = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+  return first ?? null;
+}
+
+function safeSend(channel: string, payload: unknown) {
+  const win = getMainWindow();
+  if (win) {
+    try {
+      win.webContents.send(channel, payload);
+    } catch (err) {
+      log.warn(`[Updater] Failed to send ${channel} to renderer:`, err);
+    }
+  }
+}
+
 export function initializeUpdater(mainWindow: BrowserWindow) {
   autoUpdater.logger = log;
   (autoUpdater.logger as any).transports.file.level = 'info';
@@ -32,7 +53,7 @@ export function initializeUpdater(mainWindow: BrowserWindow) {
     log.info('[Updater] Update available.', info);
     updateStatus.status = 'available';
     updateStatus.version = info.version || '';
-    mainWindow.webContents.send('update-available', info);
+    safeSend('update-available', info);
   });
   
   autoUpdater.on('update-not-available', (info) => {
@@ -44,14 +65,14 @@ export function initializeUpdater(mainWindow: BrowserWindow) {
     log.error('[Updater] Error in auto-updater. ' + err);
     updateStatus.status = 'error';
     updateStatus.errorMsg = err?.message || 'Unknown error';
-    mainWindow.webContents.send('update-error', err?.message || 'Unknown error');
+    safeSend('update-error', err?.message || 'Unknown error');
   });
   
   autoUpdater.on('download-progress', (progressObj) => {
     log.info(`[Updater] Download progress: ${progressObj.percent.toFixed(2)}%`);
     updateStatus.status = 'downloading';
     updateStatus.progress = progressObj;
-    mainWindow.webContents.send('download-progress', progressObj);
+    safeSend('download-progress', progressObj);
   });
   
   autoUpdater.on('update-downloaded', (info) => {
@@ -59,7 +80,7 @@ export function initializeUpdater(mainWindow: BrowserWindow) {
     updateStatus.status = 'downloaded';
     updateStatus.version = info.version || '';
     updateStatus.progress = null;
-    mainWindow.webContents.send('update-downloaded', info);
+    safeSend('update-downloaded', info);
   });
 
   // Listen for renderer confirming restart and update (support both send and invoke)
@@ -77,7 +98,9 @@ export function initializeUpdater(mainWindow: BrowserWindow) {
 
   // Check for updates
   try {
-    autoUpdater.checkForUpdatesAndNotify();
+    autoUpdater.checkForUpdatesAndNotify()?.catch((error: unknown) => {
+      log.error('[Updater] Async update check failed:', error);
+    });
   } catch (error) {
     log.error('[Updater] Failed to check for updates on startup:', error);
   }

--- a/main/voice-overlay.ts
+++ b/main/voice-overlay.ts
@@ -25,7 +25,6 @@ export class VoiceOverlayManager {
   private isCtrlDown = false;
   private isAltDown = false;
   private isListening = false;
-  private holdTimeout: NodeJS.Timeout | null = null;
   private otherKeyPressed = false;
   private startListeningTimeout: NodeJS.Timeout | null = null;
 
@@ -66,7 +65,6 @@ export class VoiceOverlayManager {
 
       if (stateStr === 'idle') {
         this.isListening = false;
-        if (this.holdTimeout) clearTimeout(this.holdTimeout);
         broadcastState('idle');
         if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
           this.overlayWindow.setIgnoreMouseEvents(true);
@@ -79,7 +77,6 @@ export class VoiceOverlayManager {
       } else {
         if (stateStr === 'listening') {
           this.isListening = true;
-          if (this.holdTimeout) clearTimeout(this.holdTimeout);
         } else {
           this.isListening = false;
         }
@@ -260,9 +257,8 @@ export class VoiceOverlayManager {
           if (!this.isListening) {
             console.log('[VoiceOverlay] Starting listening state...');
             this.isListening = true;
-            if (this.holdTimeout) clearTimeout(this.holdTimeout);
-            
-            if (this.overlayWindow) {
+
+            if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
               this.overlayWindow.showInactive();
               broadcastState('listening');
               console.log('[VoiceOverlay] IPC state sent: listening');
@@ -282,7 +278,7 @@ export class VoiceOverlayManager {
         console.log('[VoiceOverlay] Stopping listening state, executing...');
         this.isListening = false;
         
-        if (this.overlayWindow) {
+        if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
           broadcastState('executing');
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@assistant-ui/react": "^0.12.24",
@@ -14832,7 +14832,6 @@
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
       "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -15011,7 +15010,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -15021,7 +15019,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -18793,7 +18791,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -19647,6 +19644,19 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-builder/node_modules/ansi-regex": {
@@ -20605,7 +20615,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -20626,7 +20635,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -33581,7 +33589,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -34346,7 +34353,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     ],
     "appId": "com.everfern.desktop",
     "productName": "EverFern",
+    "afterSign": "scripts/after-sign-mac.cjs",
     "copyright": "Copyright © 2026 EverFern",
     "npmRebuild": true,
     "icon": "public/images/logos/everfern.ico",
@@ -125,7 +126,7 @@
         "zip"
       ],
       "icon": "public/images/logos/everfern.icns",
-      "hardenedRuntime": true,
+      "hardenedRuntime": false,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.inherit.plist",

--- a/preload/preload.ts
+++ b/preload/preload.ts
@@ -85,7 +85,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     ocrPdf: (params: { pdfPath: string; engine?: string; backend?: string; installIfMissing?: boolean }) => ipcRenderer.invoke('system:ocr-pdf', params),
     pdfPages: (params: { pdfPath: string; maxPages?: number; installIfMissing?: boolean }) => ipcRenderer.invoke('system:pdf-pages', params),
-    wipeAccount:    () => ipcRenderer.invoke('system:wipe-account'),
+    wipeAccount:    (confirmPhrase?: string) => ipcRenderer.invoke('system:wipe-account', confirmPhrase),
     getPermissionStatus: () => ipcRenderer.invoke('permissions:status'),
     grantPermission:     () => ipcRenderer.invoke('permissions:grant'),
     onPermissionRequest: (cb: () => void) => {
@@ -430,7 +430,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeAllListeners('agent:permission-request');
       // Intentionally NOT removing mission listeners here to allow persistent tracking
       ipcRenderer.removeAllListeners('acp:plan-created');
-      ipcRenderer.removeAllListeners('acp:hitl-request');
+      // NOTE: acp:hitl-request is intentionally NOT removed here — the chat page
+      // registers it once at mount and relies on it persisting across sends/resets.
       ipcRenderer.removeAllListeners('acp:hitl-response-processed');
       ipcRenderer.removeAllListeners('acp:sub-agent-progress');
       ipcRenderer.removeAllListeners('acp:subagent-event');
@@ -716,7 +717,7 @@ export type ElectronAPI = {
     getPlatform:    () => Promise<string>;
     openFilePicker: (options?: { filters?: { name: string; extensions: string[] }[] }) => Promise<{ path: string; name: string; content?: string; base64?: string; mimeType?: string; size?: number; success: boolean, error?: string } | null>;
     openFolderPicker: () => Promise<{ path: string; name: string; success: boolean; error?: string } | null>;
-    wipeAccount:    () => Promise<{ success: boolean; error?: string }>;
+    wipeAccount:    (confirmPhrase?: string) => Promise<{ success: boolean; error?: string }>;
     getPermissionStatus: () => Promise<{ granted: boolean }>;
     grantPermission:     () => Promise<{ success: boolean }>;
     onPermissionRequest: (cb: () => void) => void;

--- a/scripts/after-sign-mac.cjs
+++ b/scripts/after-sign-mac.cjs
@@ -25,7 +25,9 @@
  *   After electron-builder signs, walk the bundle deepest-first and re-sign
  *   every ad-hoc component WITHOUT the hardened-runtime flag. Without the
  *   runtime flag, library validation is not enforced and helpers load the
- *   framework normally.
+ *   framework normally. If anything inside the bundle was repaired, the
+ *   outermost bundle is re-signed last so its CodeResources seal stays
+ *   consistent with the modified contents.
  *
  * Builds signed with a real certificate (CSC_LINK / CSC_NAME set, or the
  * resulting signature is not ad-hoc) are detected and left untouched.
@@ -35,6 +37,14 @@ const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Run a command and resolve with { err, out } instead of throwing.
+ *
+ * @param {string} cmd - Executable to run.
+ * @param {string[]} args - Argument list for the executable.
+ * @returns {Promise<{err: Error|null, out: string}>} Combined stdout/stderr
+ *   and an error object when the command failed.
+ */
 function sh(cmd, args) {
   return new Promise((resolve) => {
     execFile(cmd, args, { encoding: 'utf8' }, (err, stdout, stderr) =>
@@ -43,6 +53,13 @@ function sh(cmd, args) {
   });
 }
 
+/**
+ * Inspect a code-signed target's signature flags.
+ *
+ * @param {string} target - Path to a Mach-O binary, framework, or app bundle.
+ * @returns {Promise<{adhoc: boolean, runtime: boolean}>} Whether the target
+ *   is ad-hoc signed and whether the hardened-runtime flag is set.
+ */
 async function codesignDetails(target) {
   const { out } = await sh('codesign', ['-dv', target]);
   const flagsLine =
@@ -53,11 +70,29 @@ async function codesignDetails(target) {
   };
 }
 
+/**
+ * Collect every nested bundle inside an .app that may need re-signing.
+ *
+ * Walks Contents/Frameworks, Contents/Plugins and Contents (depth-limited),
+ * gathering .framework and .app bundles without descending into them (each
+ * nested bundle is re-signed as a unit).
+ *
+ * @param {string} appBundle - Path to the outer .app bundle.
+ * @returns {Promise<string[]>} Bundle paths sorted deepest-first, so outer
+ *   bundles are always (re-)sealed after their contents change.
+ */
 async function findTargets(appBundle) {
   const contents = path.join(appBundle, 'Contents');
   const roots = [path.join(contents, 'Frameworks'), path.join(contents, 'Plugins'), contents];
   const found = [];
 
+  /**
+   * Recurse into a directory collecting nested bundle paths.
+   *
+   * @param {string} dir - Directory to scan.
+   * @param {number} depth - Current recursion depth (hard limit 6).
+   * @returns {Promise<void>} Resolves when the directory has been scanned.
+   */
   async function walk(dir, depth) {
     if (depth > 6) return;
     let entries;
@@ -84,6 +119,18 @@ async function findTargets(appBundle) {
   return [...new Set(found)].sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
 }
 
+/**
+ * electron-builder afterSign hook entry point.
+ *
+ * Re-signs ad-hoc hardened-runtime components without the runtime flag and
+ * re-seals the outer bundle if any nested component changed. Skips entirely
+ * on non-macOS builds and whenever a real signing identity is configured.
+ *
+ * @param {object} context - electron-builder hook context (appOutDir,
+ *   electronPlatformName, packager, etc.).
+ * @returns {Promise<void>} Resolves once the bundle is consistent; rejects
+ *   if a required re-sign fails.
+ */
 exports.default = async function afterSign(context) {
   if (context.electronPlatformName !== 'darwin') return;
 
@@ -123,7 +170,8 @@ exports.default = async function afterSign(context) {
     console.warn(`[after-sign-mac] No .app found in ${outDir} — nothing to do.`);
     return;
   }
-  // Sign the outermost bundle last.
+
+  // Deepest-first, with the outermost bundle handled last (see below).
   const targets = [...(await findTargets(appBundle)), appBundle];
 
   let repaired = 0;
@@ -145,6 +193,20 @@ exports.default = async function afterSign(context) {
         `[after-sign-mac] ${path.relative(outDir, target)} is certificate-signed — leaving as-is.`
       );
     }
+  }
+
+  // Re-signing a nested bundle invalidates the outer bundle's CodeResources
+  // seal, so the outermost bundle must always be re-sealed after any nested
+  // repair — even when its own signature didn't need the runtime flag
+  // stripped. Plain ad-hoc signing is idempotent, so this is safe to run
+  // unconditionally after a repair.
+  if (repaired > 0) {
+    const { err } = await sh('codesign', ['--force', '--sign', '-', appBundle]);
+    if (err) {
+      console.error(`[after-sign-mac] Failed to re-seal outer bundle: ${err.message}`);
+      throw err;
+    }
+    console.log('[after-sign-mac] Re-sealed outer app bundle signature.');
   }
 
   if (repaired === 0) console.log('[after-sign-mac] No ad-hoc hardened-runtime binaries found.');

--- a/scripts/after-sign-mac.cjs
+++ b/scripts/after-sign-mac.cjs
@@ -22,20 +22,26 @@
  *   because `electron .` runs the stock Developer-ID-signed binaries.
  *
  * Fix:
- *   After electron-builder signs, walk the bundle deepest-first and re-sign
- *   every ad-hoc component WITHOUT the hardened-runtime flag. Without the
- *   runtime flag, library validation is not enforced and helpers load the
- *   framework normally. If anything inside the bundle was repaired, the
- *   outermost bundle is re-signed last so its CodeResources seal stays
- *   consistent with the modified contents.
+ *   After electron-builder signs, walk the bundle and re-sign every ad-hoc
+ *   component WITHOUT the hardened-runtime flag, deepest bundle first
+ *   (Apple TN2206 inside-out order). Nested .app, .framework, .xpc and
+ *   .appex containers are all discovered, including inside other bundles.
+ *   If anything inside changed, every enclosing bundle — innermost first —
+ *   plus the outermost bundle is re-signed last, so each CodeResources seal
+ *   stays consistent with the modified contents.
  *
- * Builds signed with a real certificate (CSC_LINK / CSC_NAME set, or the
- * resulting signature is not ad-hoc) are detected and left untouched.
+ * Builds signed with a real certificate are never modified: if the outer
+ * bundle is certificate-signed, the hook exits without touching anything
+ * (repairing ad-hoc nested code would invalidate the certificate seal in a
+ * way we cannot repair without the certificate).
  */
 
 const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+
+/** Directory suffixes treated as signable nested bundles. */
+const BUNDLE_SUFFIXES = ['.app', '.framework', '.xpc', '.appex'];
 
 /**
  * Run a command and resolve with { err, out } instead of throwing.
@@ -54,47 +60,49 @@ function sh(cmd, args) {
 }
 
 /**
- * Inspect a code-signed target's signature flags.
+ * Inspect a code-signed target's signature.
  *
- * @param {string} target - Path to a Mach-O binary, framework, or app bundle.
- * @returns {Promise<{adhoc: boolean, runtime: boolean}>} Whether the target
- *   is ad-hoc signed and whether the hardened-runtime flag is set.
+ * @param {string} target - Path to a Mach-O binary, framework, or bundle.
+ * @returns {Promise<{signed: boolean, adhoc: boolean, runtime: boolean}>}
+ *   `signed` is false when the target has no signature at all; `adhoc` is
+ *   true for ad-hoc signatures; `runtime` reflects the hardened-runtime flag.
  */
 async function codesignDetails(target) {
   const { out } = await sh('codesign', ['-dv', target]);
   const flagsLine =
     (out.match(/^CodeDirectory.*?flags=0x[0-9a-fA-F]+\(([^)]*)\)/m) || [])[1] || '';
+  const signed = /^Signature=/m.test(out);
   return {
+    signed,
     adhoc: /\badhoc\b/.test(flagsLine) || /^Signature=adhoc$/m.test(out),
     runtime: /\bruntime\b/.test(flagsLine),
   };
 }
 
 /**
- * Collect every nested bundle inside an .app that may need re-signing.
+ * Collect every nested signable bundle inside an .app.
  *
- * Walks Contents/Frameworks, Contents/Plugins and Contents (depth-limited),
- * gathering .framework and .app bundles without descending into them (each
- * nested bundle is re-signed as a unit).
+ * Recurses through the bundle tree — including inside discovered bundles —
+ * gathering .app, .framework, .xpc and .appex containers, so nested XPC
+ * services or app extensions inside helper apps/frameworks are found too.
+ * Symlinked directories are not followed.
  *
  * @param {string} appBundle - Path to the outer .app bundle.
- * @returns {Promise<string[]>} Bundle paths sorted deepest-first, so outer
- *   bundles are always (re-)sealed after their contents change.
+ * @returns {Promise<string[]>} Bundle paths sorted deepest-first, so every
+ *   bundle is re-signed after its own contents (TN2206 inside-out order).
  */
 async function findTargets(appBundle) {
-  const contents = path.join(appBundle, 'Contents');
-  const roots = [path.join(contents, 'Frameworks'), path.join(contents, 'Plugins'), contents];
-  const found = [];
+  const found = new Set();
 
   /**
    * Recurse into a directory collecting nested bundle paths.
    *
    * @param {string} dir - Directory to scan.
-   * @param {number} depth - Current recursion depth (hard limit 6).
+   * @param {number} depth - Current recursion depth (hard limit 12).
    * @returns {Promise<void>} Resolves when the directory has been scanned.
    */
   async function walk(dir, depth) {
-    if (depth > 6) return;
+    if (depth > 12) return;
     let entries;
     try {
       entries = await fs.promises.readdir(dir, { withFileTypes: true });
@@ -102,21 +110,21 @@ async function findTargets(appBundle) {
       return;
     }
     for (const entry of entries) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
       const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (entry.name.endsWith('.framework') || entry.name.endsWith('.app')) {
-          found.push(full);
-          continue; // don't descend into nested bundles; they get re-signed whole
-        }
-        await walk(full, depth + 1);
+      if (BUNDLE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) {
+        found.add(full);
       }
+      // Keep recursing inside bundles too: helpers/XPC services can nest
+      // arbitrarily deep (e.g. Helper.app/Contents/Frameworks/*.framework).
+      await walk(full, depth + 1);
     }
   }
 
-  for (const root of roots) await walk(root, 0);
+  await walk(path.join(appBundle, 'Contents'), 0);
 
   // Deepest paths first so outer bundles are sealed after their contents.
-  return [...new Set(found)].sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
+  return [...found].sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
 }
 
 /**
@@ -124,7 +132,10 @@ async function findTargets(appBundle) {
  *
  * Re-signs ad-hoc hardened-runtime components without the runtime flag and
  * re-seals the outer bundle if any nested component changed. Skips entirely
- * on non-macOS builds and whenever a real signing identity is configured.
+ * on non-macOS builds, when a signing identity is configured via CSC
+ * environment variables, or when the outer bundle carries a real
+ * certificate signature (modifying nested code would invalidate that
+ * certificate's seal beyond repair).
  *
  * @param {object} context - electron-builder hook context (appOutDir,
  *   electronPlatformName, packager, etc.).
@@ -134,7 +145,9 @@ async function findTargets(appBundle) {
 exports.default = async function afterSign(context) {
   if (context.electronPlatformName !== 'darwin') return;
 
-  // Never touch builds signed with a real certificate.
+  // Never touch builds signed with a real certificate. (Note: electron-builder
+  // can also auto-discover a keychain identity when these are unset — the
+  // outer-bundle signature check below covers that case.)
   if (process.env.CSC_LINK || process.env.CSC_NAME || process.env.MAC_CERTS_P12) {
     console.log('[after-sign-mac] Signing identity configured — skipping ad-hoc repair.');
     return;
@@ -171,13 +184,28 @@ exports.default = async function afterSign(context) {
     return;
   }
 
-  // Deepest-first, with the outermost bundle handled last (see below).
-  const targets = [...(await findTargets(appBundle)), appBundle];
+  const targets = await findTargets(appBundle);
+
+  // Inspect the outer bundle BEFORE modifying anything: if it carries a real
+  // certificate signature we must not change nested code (the certificate
+  // seal would break and we cannot re-seal without the certificate).
+  const outer = await codesignDetails(appBundle);
+  if (outer.signed && !outer.adhoc) {
+    console.log(
+      '[after-sign-mac] Outer bundle is certificate-signed — leaving bundle untouched.'
+    );
+    return;
+  }
+
+  // Outermost last: it is part of the repair set when it needs flag-stripping,
+  // and is re-sealed again below if any nested bundle changed.
+  targets.push(appBundle);
 
   let repaired = 0;
+  const repairedTargets = [];
   for (const target of targets) {
-    const { adhoc, runtime } = await codesignDetails(target);
-    if (adhoc && runtime) {
+    const { signed, adhoc, runtime } = await codesignDetails(target);
+    if (signed && adhoc && runtime) {
       const rel = path.relative(outDir, target);
       // Plain ad-hoc re-sign drops the hardened-runtime flag (and its
       // entitlement requirements, which are meaningless without it).
@@ -187,20 +215,52 @@ exports.default = async function afterSign(context) {
         throw err;
       }
       repaired++;
+      repairedTargets.push(target);
       console.log(`[after-sign-mac] Stripped hardened runtime from ${rel}`);
-    } else if (!adhoc) {
+    } else if (signed && !adhoc) {
       console.log(
         `[after-sign-mac] ${path.relative(outDir, target)} is certificate-signed — leaving as-is.`
       );
     }
   }
 
-  // Re-signing a nested bundle invalidates the outer bundle's CodeResources
-  // seal, so the outermost bundle must always be re-sealed after any nested
-  // repair — even when its own signature didn't need the runtime flag
-  // stripped. Plain ad-hoc signing is idempotent, so this is safe to run
-  // unconditionally after a repair.
+  // Re-signing any nested bundle invalidates the CodeResources seal of every
+  // bundle that encloses it — not just the outermost app. Re-seal all
+  // ancestor bundles of repaired targets, innermost first, then the outer
+  // app bundle itself. Plain ad-hoc signing is idempotent, so re-sealing a
+  // bundle that was already repaired in the loop above is safe.
   if (repaired > 0) {
+    const toReseal = new Set();
+    for (const target of repairedTargets) {
+      let dir = path.dirname(target);
+      while (dir.length >= appBundle.length && dir !== appBundle) {
+        if (BUNDLE_SUFFIXES.some((suffix) => path.basename(dir).endsWith(suffix))) {
+          toReseal.add(dir);
+        }
+        dir = path.dirname(dir);
+      }
+    }
+    const ancestors = [...toReseal].sort(
+      (a, b) => b.split(path.sep).length - a.split(path.sep).length
+    );
+    for (const bundle of ancestors) {
+      const { signed, adhoc } = await codesignDetails(bundle);
+      if (signed && !adhoc) {
+        console.warn(
+          `[after-sign-mac] ⚠️  ${path.relative(outDir, bundle)} is certificate-signed but its ` +
+            'contents changed — it cannot be re-sealed without the certificate.'
+        );
+        continue;
+      }
+      const rel = path.relative(outDir, bundle);
+      const { err } = await sh('codesign', ['--force', '--sign', '-', bundle]);
+      if (err) {
+        console.error(`[after-sign-mac] Failed to re-seal ${rel}: ${err.message}`);
+        throw err;
+      }
+      console.log(`[after-sign-mac] Re-sealed ${rel}`);
+    }
+
     const { err } = await sh('codesign', ['--force', '--sign', '-', appBundle]);
     if (err) {
       console.error(`[after-sign-mac] Failed to re-seal outer bundle: ${err.message}`);

--- a/scripts/after-sign-mac.cjs
+++ b/scripts/after-sign-mac.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * electron-builder afterSign hook (macOS).
+ *
+ * Fixes grey-screen-at-launch crashes in ad-hoc signed builds (i.e. builds
+ * produced without a Developer ID certificate — the default for OSS CI).
+ *
+ * Root cause:
+ *   electron-builder re-signs the bundle ad-hoc but preserves the
+ *   hardened-runtime (`--options runtime`) flag that ships on the stock
+ *   Electron binaries. Hardened runtime turns on library validation, which
+ *   requires the loading process and the mapped library to share a Team ID.
+ *   Two independently ad-hoc-signed binaries never share one, so every
+ *   helper process dies at dyld:
+ *
+ *     dyld: Library not loaded: @rpath/Electron Framework.framework/Electron Framework
+ *       Reason: code signature ... not valid for use in process:
+ *       mapping process and mapped file (non-platform) have different Team IDs
+ *     FATAL:gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
+ *
+ *   Result: window opens grey, then the app quits. Dev mode is unaffected
+ *   because `electron .` runs the stock Developer-ID-signed binaries.
+ *
+ * Fix:
+ *   After electron-builder signs, walk the bundle deepest-first and re-sign
+ *   every ad-hoc component WITHOUT the hardened-runtime flag. Without the
+ *   runtime flag, library validation is not enforced and helpers load the
+ *   framework normally.
+ *
+ * Builds signed with a real certificate (CSC_LINK / CSC_NAME set, or the
+ * resulting signature is not ad-hoc) are detected and left untouched.
+ */
+
+const { execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function sh(cmd, args) {
+  return new Promise((resolve) => {
+    execFile(cmd, args, { encoding: 'utf8' }, (err, stdout, stderr) =>
+      resolve({ err, out: `${stdout || ''}${stderr || ''}` })
+    );
+  });
+}
+
+async function codesignDetails(target) {
+  const { out } = await sh('codesign', ['-dv', target]);
+  const flagsLine =
+    (out.match(/^CodeDirectory.*?flags=0x[0-9a-fA-F]+\(([^)]*)\)/m) || [])[1] || '';
+  return {
+    adhoc: /\badhoc\b/.test(flagsLine) || /^Signature=adhoc$/m.test(out),
+    runtime: /\bruntime\b/.test(flagsLine),
+  };
+}
+
+async function findTargets(appBundle) {
+  const contents = path.join(appBundle, 'Contents');
+  const roots = [path.join(contents, 'Frameworks'), path.join(contents, 'Plugins'), contents];
+  const found = [];
+
+  async function walk(dir, depth) {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name.endsWith('.framework') || entry.name.endsWith('.app')) {
+          found.push(full);
+          continue; // don't descend into nested bundles; they get re-signed whole
+        }
+        await walk(full, depth + 1);
+      }
+    }
+  }
+
+  for (const root of roots) await walk(root, 0);
+
+  // Deepest paths first so outer bundles are sealed after their contents.
+  return [...new Set(found)].sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
+}
+
+exports.default = async function afterSign(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+
+  // Never touch builds signed with a real certificate.
+  if (process.env.CSC_LINK || process.env.CSC_NAME || process.env.MAC_CERTS_P12) {
+    console.log('[after-sign-mac] Signing identity configured — skipping ad-hoc repair.');
+    return;
+  }
+
+  const outDir = context.appOutDir;
+  const productName = context.packager?.appInfo?.productFilename;
+  let appBundle;
+  try {
+    const candidates = fs
+      .readdirSync(outDir)
+      .filter((f) => f.endsWith('.app'))
+      .sort((a, b) => {
+        // Prefer the bundle electron-builder just produced.
+        if (productName) {
+          const aMatch = a === `${productName}.app` ? -1 : 0;
+          const bMatch = b === `${productName}.app` ? -1 : 0;
+          if (aMatch !== bMatch) return aMatch - bMatch;
+        }
+        return a.localeCompare(b);
+      })
+      .map((f) => path.join(outDir, f));
+    appBundle = candidates[0];
+    if (productName && candidates.length > 1) {
+      console.warn(
+        `[after-sign-mac] Multiple .app bundles in ${outDir}; repairing "${path.basename(appBundle)}".`
+      );
+    }
+  } catch {
+    appBundle = undefined;
+  }
+  if (!appBundle) {
+    console.warn(`[after-sign-mac] No .app found in ${outDir} — nothing to do.`);
+    return;
+  }
+  // Sign the outermost bundle last.
+  const targets = [...(await findTargets(appBundle)), appBundle];
+
+  let repaired = 0;
+  for (const target of targets) {
+    const { adhoc, runtime } = await codesignDetails(target);
+    if (adhoc && runtime) {
+      const rel = path.relative(outDir, target);
+      // Plain ad-hoc re-sign drops the hardened-runtime flag (and its
+      // entitlement requirements, which are meaningless without it).
+      const { err } = await sh('codesign', ['--force', '--sign', '-', target]);
+      if (err) {
+        console.error(`[after-sign-mac] Failed to re-sign ${rel}: ${err.message}`);
+        throw err;
+      }
+      repaired++;
+      console.log(`[after-sign-mac] Stripped hardened runtime from ${rel}`);
+    } else if (!adhoc) {
+      console.log(
+        `[after-sign-mac] ${path.relative(outDir, target)} is certificate-signed — leaving as-is.`
+      );
+    }
+  }
+
+  if (repaired === 0) console.log('[after-sign-mac] No ad-hoc hardened-runtime binaries found.');
+  else console.log(`[after-sign-mac] Repaired ${repaired} component(s); library validation off.`);
+};

--- a/src/app/chat/ArtifactsPanel.tsx
+++ b/src/app/chat/ArtifactsPanel.tsx
@@ -31,6 +31,26 @@ interface ArtifactsPanelProps {
     projectPath?: string | null;
 }
 
+// CU-STRM-02: theme-aware syntax-highlight palette. Roles map to globals.css
+// tokens (CSS vars are valid in inline styles) so highlight colors follow the
+// active light/dark theme; the low-contrast hardcoded comment gray is gone.
+// keyword/property/boolean keep their hex: globals.css has NO fuchsia/purple
+// semantic token (--color-accent is teal and reserved for function/attr/key).
+const SYNTAX_COLORS = {
+    keyword: '#d946ef',
+    string: 'var(--color-success)',        // was #16a34a
+    number: 'var(--color-info)',           // was #2563eb
+    comment: 'var(--color-text-tertiary)', // was #8a8886
+    function: 'var(--color-accent)',       // was #0891b2
+    tag: 'var(--color-error)',             // was #dc2626
+    attr: 'var(--color-accent)',
+    property: '#d946ef',
+    value: 'var(--color-info)',
+    selector: 'var(--color-error)',
+    key: 'var(--color-accent)',
+    boolean: '#d946ef',
+};
+
 // ── 1. MARKDOWN VIEWER ──────────────────────────────────────────────
 export function MarkdownViewer({ content }: { content: string }) {
     const renderMarkdown = (text: string) => {
@@ -137,7 +157,7 @@ export function MarkdownViewer({ content }: { content: string }) {
             if (line.trim().startsWith('- ') || line.trim().startsWith('* ')) {
                 const content = line.trim().substring(2);
                 elements.push(
-                    <li key={`li-${i}`} style={{ marginLeft: 20, margin: '4px 0', fontSize: 14, color: 'var(--color-text-primary)' }}
+                    <li key={`li-${i}`} style={{ margin: '4px 0 4px 20px', fontSize: 14, color: 'var(--color-text-primary)' }}
                         dangerouslySetInnerHTML={{ __html: formatInline(content) }}
                     />
                 );
@@ -1016,13 +1036,13 @@ All subprocess executions pass through strict environment isolation with explici
 // Syntax highlighting helper
 const getSyntaxHighlightingColors = (language: string, token: string): string => {
     const colorMap: Record<string, Record<string, string>> = {
-        javascript: { keyword: '#d946ef', string: '#16a34a', number: '#2563eb', comment: '#8a8886', function: '#0891b2' },
-        typescript: { keyword: '#d946ef', string: '#16a34a', number: '#2563eb', comment: '#8a8886', function: '#0891b2' },
-        python: { keyword: '#d946ef', string: '#16a34a', number: '#2563eb', comment: '#8a8886', function: '#0891b2' },
-        html: { tag: '#dc2626', attr: '#0891b2', string: '#16a34a', comment: '#8a8886' },
-        css: { property: '#d946ef', value: '#2563eb', selector: '#dc2626', comment: '#8a8886' },
-        json: { key: '#0891b2', string: '#16a34a', number: '#2563eb', boolean: '#d946ef' },
-        sql: { keyword: '#d946ef', string: '#16a34a', number: '#2563eb', comment: '#8a8886' },
+        javascript: { keyword: SYNTAX_COLORS.keyword, string: SYNTAX_COLORS.string, number: SYNTAX_COLORS.number, comment: SYNTAX_COLORS.comment, function: SYNTAX_COLORS.function },
+        typescript: { keyword: SYNTAX_COLORS.keyword, string: SYNTAX_COLORS.string, number: SYNTAX_COLORS.number, comment: SYNTAX_COLORS.comment, function: SYNTAX_COLORS.function },
+        python: { keyword: SYNTAX_COLORS.keyword, string: SYNTAX_COLORS.string, number: SYNTAX_COLORS.number, comment: SYNTAX_COLORS.comment, function: SYNTAX_COLORS.function },
+        html: { tag: SYNTAX_COLORS.tag, attr: SYNTAX_COLORS.attr, string: SYNTAX_COLORS.string, comment: SYNTAX_COLORS.comment },
+        css: { property: SYNTAX_COLORS.property, value: SYNTAX_COLORS.value, selector: SYNTAX_COLORS.selector, comment: SYNTAX_COLORS.comment },
+        json: { key: SYNTAX_COLORS.key, string: SYNTAX_COLORS.string, number: SYNTAX_COLORS.number, boolean: SYNTAX_COLORS.boolean },
+        sql: { keyword: SYNTAX_COLORS.keyword, string: SYNTAX_COLORS.string, number: SYNTAX_COLORS.number, comment: SYNTAX_COLORS.comment },
     };
     return colorMap[language]?.[token] || 'var(--color-text-primary)';
 };
@@ -1043,43 +1063,43 @@ const detectLanguage = (filename: string): string => {
 export const SyntaxHighlighter = ({ code, language }: { code: string; language: string }) => {
     const colorSchemes: Record<string, Record<string, string>> = {
         python: {
-            keyword: '#d946ef',
-            string: '#16a34a',
-            number: '#2563eb',
-            comment: '#8a8886',
-            function: '#0891b2',
+            keyword: SYNTAX_COLORS.keyword,
+            string: SYNTAX_COLORS.string,
+            number: SYNTAX_COLORS.number,
+            comment: SYNTAX_COLORS.comment,
+            function: SYNTAX_COLORS.function,
         },
         javascript: {
-            keyword: '#d946ef',
-            string: '#16a34a',
-            number: '#2563eb',
-            comment: '#8a8886',
-            function: '#0891b2',
+            keyword: SYNTAX_COLORS.keyword,
+            string: SYNTAX_COLORS.string,
+            number: SYNTAX_COLORS.number,
+            comment: SYNTAX_COLORS.comment,
+            function: SYNTAX_COLORS.function,
         },
         typescript: {
-            keyword: '#d946ef',
-            string: '#16a34a',
-            number: '#2563eb',
-            comment: '#8a8886',
-            function: '#0891b2',
+            keyword: SYNTAX_COLORS.keyword,
+            string: SYNTAX_COLORS.string,
+            number: SYNTAX_COLORS.number,
+            comment: SYNTAX_COLORS.comment,
+            function: SYNTAX_COLORS.function,
         },
         html: {
-            tag: '#dc2626',
-            attr: '#0891b2',
-            string: '#16a34a',
-            comment: '#8a8886',
+            tag: SYNTAX_COLORS.tag,
+            attr: SYNTAX_COLORS.attr,
+            string: SYNTAX_COLORS.string,
+            comment: SYNTAX_COLORS.comment,
         },
         css: {
-            property: '#d946ef',
-            value: '#2563eb',
-            selector: '#dc2626',
-            comment: '#8a8886',
+            property: SYNTAX_COLORS.property,
+            value: SYNTAX_COLORS.value,
+            selector: SYNTAX_COLORS.selector,
+            comment: SYNTAX_COLORS.comment,
         },
         json: {
-            key: '#0891b2',
-            string: '#16a34a',
-            number: '#2563eb',
-            boolean: '#d946ef',
+            key: SYNTAX_COLORS.key,
+            string: SYNTAX_COLORS.string,
+            number: SYNTAX_COLORS.number,
+            boolean: SYNTAX_COLORS.boolean,
         },
     };
 
@@ -1979,8 +1999,8 @@ export default function ArtifactsPanel({ isOpen, onClose, activeChatId, onApprov
                                                 >
                                                     {/* Site preview */}
                                                     <div style={{ flex: 1, backgroundColor: "var(--color-bg-subtle)", overflow: "hidden", position: "relative" }}>
-                                                        <iframe 
-                                                            srcDoc={`<html><head><style>body{margin:0;padding:16px;font-family:system-ui}</style></head><body><p style="color:var(--color-text-tertiary);font-size:12px">Loading preview...</p></body></html>`}
+                                                        <iframe
+                                                            src={`everfern-site://${site.chatId}/index.html`}
                                                             style={{ width: "100%", height: "100%", border: "none", backgroundColor: "var(--color-bg-subtle)" }}
                                                             title="Preview"
                                                             sandbox="allow-scripts"

--- a/src/app/chat/SettingsPage.tsx
+++ b/src/app/chat/SettingsPage.tsx
@@ -2342,6 +2342,10 @@ export default function SettingsPage({
     const [showVectorsModal, setShowVectorsModal] = useState(false);
     const [vectorsData, setVectorsData] = useState<any[]>([]);
     const [loadingVectors, setLoadingVectors] = useState(false);
+    const [showWipeConfirm, setShowWipeConfirm] = useState(false);
+    const [wipePhrase, setWipePhrase] = useState('');
+    // Must match main/ipc/system/window-fs-handlers WIPE_ACCOUNT_CONFIRM_PHRASE (renderer can't import main's constant).
+    const WIPE_CONFIRM_PHRASE = 'DELETE MY DATA';
     const router = useRouter();
 
     // ── Local Model Discovery & Benchmark State ──────────────────────────────
@@ -4451,39 +4455,65 @@ export default function SettingsPage({
             <div style={{ backgroundColor: 'var(--color-error-dim)', border: '1px solid var(--color-error-dim)', borderRadius: 16, padding: 24 }}>
                 <h3 style={{ fontSize: 15, fontWeight: 600, color: 'var(--color-error)', margin: '0 0 8px' }}>Danger Zone</h3>
                 <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: '0 0 16px', lineHeight: 1.6 }}>Wipe all local data, search API keys, tool configurations, and reset your account. This cannot be undone.</p>
-                <button
-                    onClick={async () => {
-                        if (!window.confirm('Are you sure you want to reset your account? This will permanently delete all conversations, search API keys, settings, and local data.')) return;
-                        try {
-                            try {
-                                await (window as any).electronAPI?.toolSettings?.set?.({
-                                    webSearch: { mode: 'local', provider: 'exa', headless: true, apiKey: '', exaApiKey: '', firecrawlApiKey: '' },
-                                    webCrawl: { mode: 'local', headless: true, apiKey: '' },
-                                    browserUse: { mode: 'local', headless: false, apiKey: '' },
-                                    navis: { useVision: false, onlyVision: false, headless: false, maxSteps: 200, useChromeProfile: true, selectedBrowserId: 'chrome', useIsolatedBrowser: false, automationMode: 'extension-first' },
-                                });
-                            } catch (e) {
-                                console.warn('toolSettings reset error:', e);
-                            }
-                            const result = await (window as any).electronAPI?.system.wipeAccount();
-                            if (result?.success) {
-                                localStorage.clear();
-                                sessionStorage.clear();
-                                window.location.reload();
-                            } else {
-                                alert(`Reset failed: ${result?.error || 'Unknown error'}`);
-                            }
-                        } catch (err: any) {
-                            alert(`Reset failed: ${err?.message || 'Unknown error'}`);
-                        }
-                    }}
-                    style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', backgroundColor: 'var(--color-error-dim)', color: 'var(--color-error)', borderRadius: 10, fontWeight: 600, fontSize: 13, border: '1px solid var(--color-error-dim)', cursor: 'pointer', transition: 'all 0.2s' }}
-                    onMouseEnter={e => e.currentTarget.style.backgroundColor = 'var(--color-error-dim)'}
-                    onMouseLeave={e => e.currentTarget.style.backgroundColor = 'var(--color-error-dim)'}
-                >
-                    <TrashIcon width={16} height={16} />
-                    Reset Account & Delete All Data
-                </button>
+                {!showWipeConfirm ? (
+                    <button
+                        onClick={() => setShowWipeConfirm(true)}
+                        style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', backgroundColor: 'var(--color-error-dim)', color: 'var(--color-error)', borderRadius: 10, fontWeight: 600, fontSize: 13, border: '1px solid var(--color-error-dim)', cursor: 'pointer', transition: 'all 0.2s' }}
+                    >
+                        <TrashIcon width={16} height={16} />
+                        Reset Account & Delete All Data
+                    </button>
+                ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                        <input
+                            type="text"
+                            value={wipePhrase}
+                            onChange={e => setWipePhrase(e.target.value)}
+                            placeholder={`Type "${WIPE_CONFIRM_PHRASE}" to confirm`}
+                            autoFocus
+                            style={{ padding: '10px 14px', backgroundColor: 'var(--color-bg-elevated)', color: 'var(--color-text-primary)', borderRadius: 8, fontSize: 13, border: '1px solid var(--color-border)', outline: 'none', fontFamily: 'monospace' }}
+                        />
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <button
+                                disabled={wipePhrase.trim() !== WIPE_CONFIRM_PHRASE}
+                                onClick={async () => {
+                                    try {
+                                        try {
+                                            await (window as any).electronAPI?.toolSettings?.set?.({
+                                                webSearch: { mode: 'local', provider: 'exa', headless: true, apiKey: '', exaApiKey: '', firecrawlApiKey: '' },
+                                                webCrawl: { mode: 'local', headless: true, apiKey: '' },
+                                                browserUse: { mode: 'local', headless: false, apiKey: '' },
+                                                navis: { useVision: false, onlyVision: false, headless: false, maxSteps: 200, useChromeProfile: true, selectedBrowserId: 'chrome', useIsolatedBrowser: false, automationMode: 'extension-first' },
+                                            });
+                                        } catch (e) {
+                                            console.warn('toolSettings reset error:', e);
+                                        }
+                                        const result = await (window as any).electronAPI?.system.wipeAccount(wipePhrase.trim());
+                                        if (result?.success) {
+                                            localStorage.clear();
+                                            sessionStorage.clear();
+                                            window.location.reload();
+                                        } else {
+                                            alert(`Reset failed: ${result?.error || 'Unknown error'}`);
+                                        }
+                                    } catch (err: any) {
+                                        alert(`Reset failed: ${err?.message || 'Unknown error'}`);
+                                    }
+                                }}
+                                style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', backgroundColor: wipePhrase.trim() === WIPE_CONFIRM_PHRASE ? 'var(--color-error)' : 'var(--color-error-dim)', color: wipePhrase.trim() === WIPE_CONFIRM_PHRASE ? '#ffffff' : 'var(--color-error)', borderRadius: 10, fontWeight: 600, fontSize: 13, border: '1px solid var(--color-error)', cursor: wipePhrase.trim() === WIPE_CONFIRM_PHRASE ? 'pointer' : 'not-allowed', opacity: wipePhrase.trim() === WIPE_CONFIRM_PHRASE ? 1 : 0.6, transition: 'all 0.2s' }}
+                            >
+                                <TrashIcon width={16} height={16} />
+                                Confirm Reset
+                            </button>
+                            <button
+                                onClick={() => { setShowWipeConfirm(false); setWipePhrase(''); }}
+                                style={{ padding: '10px 20px', backgroundColor: 'var(--color-bg-subtle)', color: 'var(--color-text-primary)', borderRadius: 10, fontWeight: 500, fontSize: 13, border: '1px solid var(--color-border)', cursor: 'pointer', transition: 'all 0.2s' }}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/app/chat/components/DocumentCard.tsx
+++ b/src/app/chat/components/DocumentCard.tsx
@@ -1,12 +1,24 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTheme } from '@/components/ThemeProvider';
+import { esc } from './ToolCallDetailPane';
 
 interface DocumentCardProps {
     path: string;
     description: string;
     chatId: string;
     onOpenArtifact?: (name: string) => void;
+}
+
+/* CU-UI-01 XSS HARDENING: raw document text must pass through esc()
+   before the formatter injects trusted markup, so attacker markup stays
+   inert while formatter-generated <code>/<strong> tags remain literal. */
+export function formatInlineText(text: string, isDark: boolean): string {
+    let f = esc(text);
+    const codeBg = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+    f = f.replace(/`(.*?)`/g, `<code style="background-color: ${codeBg}; padding: 2px 4px; border-radius: 4px; font-family: monospace; font-size: 12px; color: #3b82f6;">$1</code>`);
+    f = f.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+    return f;
 }
 
 export default function DocumentCard({ path, description, chatId, onOpenArtifact }: DocumentCardProps) {
@@ -108,17 +120,7 @@ export default function DocumentCard({ path, description, chatId, onOpenArtifact
         }
     };
 
-    const formatInline = (text: string) => {
-        let f = text;
-        // Escape HTML
-        f = f.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        // Inline code
-        const codeBg = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
-        f = f.replace(/`(.*?)`/g, `<code style="background-color: ${codeBg}; padding: 2px 4px; border-radius: 4px; font-family: monospace; font-size: 12px; color: #3b82f6;">$1</code>`);
-        // Inline bold
-        f = f.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-        return f;
-    };
+    const formatInline = (text: string) => formatInlineText(text, isDark);
 
     const renderPreviewContent = () => {
         if (loading) {

--- a/src/app/chat/components/ToolCallComponents.tsx
+++ b/src/app/chat/components/ToolCallComponents.tsx
@@ -388,7 +388,7 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({ result, index }) =>
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.2, delay: index * 0.03 }}
             onClick={() => window.open(result.url, '_blank')}
-            className="flex items-center gap-3 px-4 py-2.5 hover:bg-[#f8fafc] transition-colors cursor-pointer border-b border-[#f1f5f9] last:border-0"
+            className="flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--color-bg-hover)] transition-colors cursor-pointer border-b border-[var(--color-border-subtle)] last:border-0"
         >
             <div className="flex shrink-0 items-center justify-center w-5 h-5">
                 <img
@@ -403,12 +403,12 @@ const SearchResultCard: React.FC<SearchResultCardProps> = ({ result, index }) =>
             </div>
 
             <div className="flex-1 min-w-0">
-                <div className="text-[13px] font-medium text-[#334155] truncate leading-none py-0.5">
+                <div className="text-[13px] font-medium text-[var(--color-text-secondary)] truncate leading-none py-0.5">
                     {title}
                 </div>
             </div>
 
-            <div className="text-[12px] text-[#94a3b8] font-normal shrink-0">
+            <div className="text-[12px] text-[var(--color-text-tertiary)] font-normal shrink-0">
                 {domain}
             </div>
         </motion.article>
@@ -441,7 +441,7 @@ const ToolCallTag = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay;
                     border: looksLikeTerminal ? '1.5px solid rgba(0,0,0,0.15)' : running ? '1.5px solid rgba(0,0,0,0.1)' : errored ? '1.5px solid rgba(239,68,68,0.2)' : '1.5px solid rgba(34,197,94,0.2)',
                 }}>
                     {running ? (
-                        <Loader size={8} strokeWidth={2} className="text-zinc-500" />
+                        <Loader size={8} strokeWidth={2} className="text-[var(--color-text-tertiary)]" />
                     ) : errored ? (
                         <XMarkIcon width={10} height={10} color="#ef4444" strokeWidth={3} />
                     ) : looksLikeTerminal ? (
@@ -749,7 +749,7 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
         >
             {/* Vertical branch line */}
             {!isLast && (
-                <div className="absolute left-[7px] top-5 bottom-[-4px] w-0.5 bg-[#e5e7eb] z-0" />
+                <div className="absolute left-[7px] top-5 bottom-[-4px] w-0.5 bg-[var(--color-border)] z-0" />
             )}
 
             <div
@@ -771,8 +771,8 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                 aria-label={isSkill ? `Skill - ${skillName || tc.toolName}` : `Tool: ${tc.label || tc.displayName || tc.toolName}`}
                 className={`flex items-center gap-3 relative z-1 ${hasOutput ? 'cursor-pointer' : 'cursor-default'} px-3 py-2 rounded-lg transition-all ${
                     isSelected
-                        ? 'bg-indigo-50 border border-indigo-200'
-                        : 'hover:bg-gray-50'
+                        ? 'bg-[var(--color-bg-active)] border border-indigo-200'
+                        : 'hover:bg-[var(--color-bg-hover)]'
                 }`}
                 style={{
                     outline: 'none',
@@ -786,7 +786,7 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                 }}
             >
                 {/* Status Icon / Globe for Search */}
-                <div className="flex items-center justify-center w-4 h-4 bg-white">
+                <div className="flex items-center justify-center w-4 h-4 bg-[var(--color-bg-elevated)]">
                     {isSearchTool ? (
                         <img src="/assets/tool-search.svg" className="w-[18px] h-[18px] opacity-75" alt="Search" />
                     ) : statusIcon}
@@ -794,15 +794,15 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
  
                 {/* Title and Results Count */}
                 <div className="flex items-center gap-2 flex-1 overflow-hidden">
-                    {!isSearchTool && <span className="flex items-center text-[#6b7280]">{iconToDisplay}</span>}
+                    {!isSearchTool && <span className="flex items-center text-[var(--color-text-secondary)]">{iconToDisplay}</span>}
                     <div className="flex-1 flex items-center justify-between overflow-hidden">
-                        <span className={`text-[15px] overflow-hidden text-ellipsis whitespace-nowrap font-normal tracking-[-0.01em] ${isSearchTool ? 'text-[#888888]' : isError ? 'text-[#ef4444]' : 'text-[#111111]'}`}
+                        <span className={`text-[15px] overflow-hidden text-ellipsis whitespace-nowrap font-normal tracking-[-0.01em] ${isSearchTool ? 'text-[var(--color-text-tertiary)]' : isError ? 'text-[#ef4444]' : 'text-[var(--color-text-primary)]'}`}
                             style={{ fontFamily: "'Matter', sans-serif" }}>
                             {isSkill ? `Skill - ${skillName || tc.label || tc.toolName}` : (tc.label || tc.displayName || tc.toolName)}
                         </span>
 
                         {isSearchTool && Array.isArray(tc.data?.results) && (
-                            <span className="text-[13px] text-[#888888] font-normal ml-auto shrink-0 pr-1">
+                            <span className="text-[13px] text-[var(--color-text-tertiary)] font-normal ml-auto shrink-0 pr-1">
                                 {tc.data.results.length} results
                             </span>
                         )}
@@ -814,7 +814,7 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                 {hasOutput && (
                     <motion.span
                         animate={{ rotate: expanded ? 0 : 90 }}
-                        className="flex shrink-0 text-[#9ca3af]"
+                        className="flex shrink-0 text-[var(--color-text-tertiary)]"
                     >
                         <ChevronUpIcon width={14} height={14} strokeWidth={2.5} />
                     </motion.span>
@@ -824,11 +824,11 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                 {isTerminal && hasOutput && !expanded && (
                     <div className="flex items-center gap-1.5">
                         {isError ? (
-                            <div className="text-[11px] text-red-600 bg-red-100 px-1.5 py-0.5 rounded font-medium animate-pulse">
+                            <div className="text-[11px] text-red-600 bg-[var(--color-error-dim)] px-1.5 py-0.5 rounded font-medium animate-pulse">
                                 Failed
                             </div>
                         ) : (
-                            <div className="text-[11px] text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded font-medium">
+                            <div className="text-[11px] text-emerald-600 bg-[var(--color-success-dim)] px-1.5 py-0.5 rounded font-medium">
                                 output
                             </div>
                         )}
@@ -850,10 +850,10 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                             <div className="flex flex-col gap-4 pb-1">
                                 {queries.length > 0 && (
                                     <div>
-                                        <div className="text-[13px] text-[#6b7280] font-medium mb-2" style={{ fontFamily: "'Matter', sans-serif" }}>Querying</div>
+                                        <div className="text-[13px] text-[var(--color-text-secondary)] font-medium mb-2" style={{ fontFamily: "'Matter', sans-serif" }}>Querying</div>
                                         <div className="flex flex-wrap gap-2">
                                             {queries.map((q, i) => (
-                                                <div key={i} className="flex items-center gap-1.5 px-3 py-1.5 rounded-[20px] bg-[#f3f4f6] border border-transparent text-[13px] text-[#374151] font-medium cursor-default transition-all duration-150 hover:bg-[#e5e7eb]"
+                                                <div key={i} className="flex items-center gap-1.5 px-3 py-1.5 rounded-[20px] bg-[var(--color-bg-subtle)] border border-transparent text-[13px] text-[var(--color-text-secondary)] font-medium cursor-default transition-all duration-150 hover:bg-[var(--color-bg-active)]"
                                                     style={{ fontFamily: "'Matter', sans-serif" }}>
                                                     <img src="/assets/tool-search.svg" className="w-3.5 h-3.5 opacity-70" alt="Search" />
                                                     {q}
@@ -864,10 +864,10 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
                                 )}
                                 {docs.length > 0 && (
                                     <div>
-                                        <div className="text-[13px] text-[#6b7280] font-medium mb-2" style={{ fontFamily: "'Matter', sans-serif" }}>Reading</div>
+                                        <div className="text-[13px] text-[var(--color-text-secondary)] font-medium mb-2" style={{ fontFamily: "'Matter', sans-serif" }}>Reading</div>
                                         <div className="flex flex-wrap gap-2 items-center">
                                             {docs.slice(0, 2).map((d, i) => (
-                                                <div key={i} className="flex items-center gap-1.5 px-3 py-1.5 rounded-[20px] bg-[#f3f4f6] border border-transparent text-[13px] text-[#374151] font-medium cursor-pointer transition-all duration-150 hover:bg-[#e5e7eb]"
+                                                <div key={i} className="flex items-center gap-1.5 px-3 py-1.5 rounded-[20px] bg-[var(--color-bg-subtle)] border border-transparent text-[13px] text-[var(--color-text-secondary)] font-medium cursor-pointer transition-all duration-150 hover:bg-[var(--color-bg-active)]"
                                                     style={{ fontFamily: "'Matter', sans-serif" }}>
                                                     <DocumentTextIcon width={14} height={14} color='var(--color-text-primary)' strokeWidth={2} />
                                                     {d}
@@ -934,8 +934,8 @@ const ToolCallRow = ({ tc, isLast, onClick, isSelected }: { tc: ToolCallDisplay,
 const scrollbarStyles = `
   .custom-scrollbar::-webkit-scrollbar { width: 6px; }
   .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
-  .custom-scrollbar::-webkit-scrollbar-thumb { background: #e5e7eb; border-radius: 10px; }
-  .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #d1d5db; }
+  .custom-scrollbar::-webkit-scrollbar-thumb { background: var(--color-bg-active); border-radius: 10px; }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: var(--color-text-tertiary); }
 `;
 
 
@@ -1104,7 +1104,7 @@ const ComputerUseResultCard = ({ tc }: { tc: ToolCallDisplay }) => {
                     </div>
 
                     <div className="flex items-center flex-wrap gap-3 text-xs">
-                        <div className="flex items-center gap-1.5 text-[#4b5563] bg-[#f9fafb] border border-[#e5e7eb] px-3 py-1.5 rounded-[20px]">
+                        <div className="flex items-center gap-1.5 text-[var(--color-text-secondary)] bg-[var(--color-bg-subtle)] border border-[var(--color-border)] px-3 py-1.5 rounded-[20px]">
                             <span className="font-medium">Tool used</span>
                             <div className={`flex items-center gap-1 text-white px-2 py-0.5 rounded-xl text-[11px] font-semibold ${finalStatus === 'executing' ? 'bg-[#3b82f6]' : finalStatus === 'error' ? 'bg-[#ef4444]' : 'bg-[#22c55e]'}`}>
                                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1116,12 +1116,12 @@ const ComputerUseResultCard = ({ tc }: { tc: ToolCallDisplay }) => {
                             </div>
                         </div>
                         {finalStatus !== 'executing' && (
-                            <div className="flex items-center gap-1.5 text-[#4b5563] bg-[#f9fafb] border border-[#e5e7eb] px-3 py-1.5 rounded-[20px]">
+                            <div className="flex items-center gap-1.5 text-[var(--color-text-secondary)] bg-[var(--color-bg-subtle)] border border-[var(--color-border)] px-3 py-1.5 rounded-[20px]">
                                 <span>Duration</span>
-                                <span className="font-semibold text-[#111827]">{(tc.durationMs ? tc.durationMs / 1000 : 2.3).toFixed(1)}s</span>
+                                <span className="font-semibold text-[var(--color-text-primary)]">{(tc.durationMs ? tc.durationMs / 1000 : 2.3).toFixed(1)}s</span>
                             </div>
                         )}
-                        <div className="flex items-center gap-1.5 text-[#4b5563] bg-[#f9fafb] border border-[#e5e7eb] px-3 py-1.5 rounded-[20px]">
+                        <div className="flex items-center gap-1.5 text-[var(--color-text-secondary)] bg-[var(--color-bg-subtle)] border border-[var(--color-border)] px-3 py-1.5 rounded-[20px]">
                             <span>Status</span>
                             <span className={`font-semibold ${finalStatus === 'executing' ? 'text-[#3b82f6]' : finalStatus === 'error' ? 'text-[#ef4444]' : 'text-[#22c55e]'}`}>
                                 {finalStatus === 'executing' ? 'Executing...' : finalStatus === 'error' ? 'Error' : 'Success'}
@@ -1166,23 +1166,23 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 400, damping: 30 }}
-                className="rounded-2xl border border-indigo-100 overflow-hidden mb-4 shadow-lg shadow-indigo-500/5 ring-1 ring-indigo-500/10 bg-white"
+                className="rounded-2xl border border-indigo-100 overflow-hidden mb-4 shadow-lg shadow-indigo-500/5 ring-1 ring-indigo-500/10 bg-[var(--color-bg-surface)]"
             >
                 {/* Header */}
-                <div className="flex items-center gap-3 px-4 py-3 bg-gradient-to-r from-indigo-50/50 via-white to-white border-b border-indigo-50">
+                <div className="flex items-center gap-3 px-4 py-3 bg-gradient-to-r from-[var(--color-navis-active-bg)] via-[var(--color-bg-surface)] to-[var(--color-bg-surface)] border-b border-indigo-50">
                     <div className="relative">
                         <div className="absolute inset-0 bg-indigo-400 rounded-full animate-ping opacity-20" />
-                        <div className="relative flex items-center justify-center w-6 h-6 bg-indigo-50 rounded-full text-indigo-600">
+                        <div className="relative flex items-center justify-center w-6 h-6 bg-[var(--color-navis-active-bg)] rounded-full text-indigo-600">
                             <DocumentTextIcon width={14} height={14} strokeWidth={2.5} />
                         </div>
                     </div>
 
                     <div className="flex flex-col min-w-0">
-                        <span className="text-[13px] font-bold text-slate-800 flex items-center gap-1.5 leading-none">
+                        <span className="text-[13px] font-bold text-[var(--color-text-primary)] flex items-center gap-1.5 leading-none">
                             {fileName || 'Initializing File...'}
                         </span>
                         {directory && (
-                            <span className="text-[10px] text-slate-400 font-mono truncate max-w-[250px] mt-0.5">
+                            <span className="text-[10px] text-[var(--color-text-tertiary)] font-mono truncate max-w-[250px] mt-0.5">
                                 {directory}
                             </span>
                         )}
@@ -1190,8 +1190,8 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
 
                     <span className={`ml-auto text-[9px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${
                         actionType === 'edit'
-                            ? 'text-purple-600 bg-purple-50 border border-purple-100 animate-pulse'
-                            : 'text-indigo-600 bg-indigo-50 border border-indigo-100 animate-pulse'
+                            ? 'text-purple-600 bg-[var(--color-navis-active-bg)] border border-purple-100 animate-pulse'
+                            : 'text-indigo-600 bg-[var(--color-navis-active-bg)] border border-indigo-100 animate-pulse'
                     }`}>
                         {actionType === 'edit' ? 'Streaming Edit' : 'Streaming Write'}
                     </span>
@@ -1212,9 +1212,9 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
                             </div>
                         </div>
                     ) : (
-                        <div className="flex flex-col items-center justify-center py-8 px-4 text-center bg-slate-50/50">
+                        <div className="flex flex-col items-center justify-center py-8 px-4 text-center bg-[var(--color-bg-subtle)]">
                             <Loader size={16} strokeWidth={2.5} className="text-indigo-500 mb-2" />
-                            <span className="text-xs text-slate-400 font-mono">
+                            <span className="text-xs text-[var(--color-text-tertiary)] font-mono">
                                 Waiting for code stream...
                             </span>
                         </div>
@@ -1238,24 +1238,24 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
             className={`rounded-2xl border overflow-hidden mb-4 transition-all duration-300 ${
                 isStreaming
-                    ? 'border-[#e2e8f0] shadow-lg shadow-indigo-500/5 ring-1 ring-indigo-500/10'
-                    : 'border-emerald-200 shadow-sm bg-emerald-50/30'
+                    ? 'border-[var(--color-border)] shadow-lg shadow-indigo-500/5 ring-1 ring-indigo-500/10'
+                    : 'border-emerald-200 shadow-sm bg-[var(--color-success-dim)]'
             }`}
         >
             {/* Header */}
             <div className={`flex items-center gap-3 px-4 py-3 ${
-                isStreaming ? 'bg-gradient-to-r from-indigo-50/50 to-white' : 'bg-emerald-50/50'
+                isStreaming ? 'bg-gradient-to-r from-[var(--color-navis-active-bg)] to-[var(--color-bg-surface)]' : 'bg-[var(--color-success-dim)]'
             }`}>
                 <div className="relative">
                     {isStreaming ? (
                         <>
                             <div className="absolute inset-0 bg-indigo-400 rounded-full animate-ping opacity-20" />
-                            <div className="relative flex items-center justify-center w-5 h-5 bg-indigo-100 rounded-full">
+                            <div className="relative flex items-center justify-center w-5 h-5 bg-[var(--color-navis-active-hover)] rounded-full">
                                 <Loader size={12} strokeWidth={2.5} className="text-indigo-600" />
                             </div>
                         </>
                     ) : (
-                        <div className="flex items-center justify-center w-5 h-5 bg-emerald-100 rounded-full">
+                        <div className="flex items-center justify-center w-5 h-5 bg-[var(--color-success-dim)] rounded-full">
                             <CheckIcon width={12} height={12} className="text-emerald-600" strokeWidth={3} />
                         </div>
                     )}
@@ -1263,7 +1263,7 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
 
                 <div className="flex flex-col gap-0.5">
                     <span className={`text-[13px] font-bold tracking-tight ${
-                        isStreaming ? 'text-slate-900' : 'text-emerald-900'
+                        isStreaming ? 'text-[var(--color-text-primary)]' : 'text-emerald-900'
                     }`}>
                         {displayName}
                     </span>
@@ -1275,7 +1275,7 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
                 </div>
 
                 {!isStreaming && (
-                    <span className="ml-auto text-[11px] text-emerald-600 font-medium bg-emerald-100/50 px-2 py-0.5 rounded-full">
+                    <span className="ml-auto text-[11px] text-emerald-600 font-medium bg-[var(--color-success-dim)] px-2 py-0.5 rounded-full">
                         Ready
                     </span>
                 )}
@@ -1284,8 +1284,8 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
             {/* Arguments Container */}
             {partialArguments && (
                 <div className="relative group">
-                    <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent opacity-50" />
-                    <pre className="m-0 px-5 py-4 text-[12px] font-mono leading-relaxed text-slate-700 bg-white/80 backdrop-blur-sm overflow-x-auto whitespace-pre-wrap max-h-[300px] custom-scrollbar selection:bg-indigo-100">
+                    <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--color-border)] to-transparent opacity-50" />
+                    <pre className="m-0 px-5 py-4 text-[12px] font-mono leading-relaxed text-[var(--color-text-secondary)] bg-[var(--glass-bg)] backdrop-blur-sm overflow-x-auto whitespace-pre-wrap max-h-[300px] custom-scrollbar selection:bg-[var(--color-navis-active-bg)]">
                         <code className="relative">
                             {partialArguments}
                             {isStreaming && (
@@ -1298,7 +1298,7 @@ export const LiveToolCallCard = ({ toolName, partialArguments, isStreaming }: Li
                     </pre>
 
                     {/* Decorative mono label */}
-                    <div className="absolute bottom-2 right-4 px-1.5 py-0.5 rounded border border-slate-100 bg-slate-50/50 text-[9px] font-mono text-slate-400 uppercase tracking-tighter opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="absolute bottom-2 right-4 px-1.5 py-0.5 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] text-[9px] font-mono text-[var(--color-text-tertiary)] uppercase tracking-tighter opacity-0 group-hover:opacity-100 transition-opacity">
                         JSON PARAMS
                     </div>
                 </div>

--- a/src/app/chat/components/ToolCallDetailPane.tsx
+++ b/src/app/chat/components/ToolCallDetailPane.tsx
@@ -12,6 +12,55 @@ import { PlanArtifact } from './PlanArtifact';
 import ToolCallCodePane from '@/components/tools/ToolCallCodePane';
 
 /* ============================================================
+   CU-UI-01 XSS HARDENING
+   Every dangerouslySetInnerHTML sink in this file renders model/tool
+   text. Raw text MUST go through esc() BEFORE any formatter injects
+   trusted markup (<span>/<code>/<strong>), so attacker markup such as
+   "<img onerror=...>" stays inert while formatter-generated tags remain
+   literal HTML. esc() also strips Private Use Area characters, which
+   the highlighters reserve as internal placeholders.
+   ============================================================ */
+export function esc(s: string): string {
+  return s
+    .replace(/[\ue000-\uf8ff]/g, '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/* Sequential .replace passes used to match inside previously injected
+   style="..." attributes (hex/property/attr-name passes re-coloring the
+   injected "color:" values), corrupting the emitted HTML. Since esc()
+   removes every raw double-quote from user text, the only remaining
+   style="..." occurrences are formatter-injected, so they can be hidden
+   behind single PUA placeholder chars after each pass and restored at
+   the end of a highlighter run. The stash is scoped to a single
+   highlighter run (a fresh array per highlightLine()/highlightSyntax()
+   invocation, passed down through the helpers), so it never grows
+   across renders and placeholder indices reset every pass; only a
+   single line holding >PUA_RANGE injected styles could still wrap the
+   alphabet (worst case a wrong-but-well-formed style value — cosmetic). */
+const PUA_BASE = 0xe000;
+const PUA_RANGE = 0xf8ff - 0xe000 + 1;
+type StyleAttrStash = string[];
+
+function stashInjectedStyles(s: string, stash: StyleAttrStash): string {
+  return s.replace(/style="[^"]*"/g, (m) =>
+    String.fromCharCode(PUA_BASE + (stash.push(m) - 1) % PUA_RANGE)
+  );
+}
+
+function unstashInjectedStyles(s: string, stash: StyleAttrStash): string {
+  return s.replace(/[\ue000-\uf8ff]/g, (c) => stash[c.charCodeAt(0) - PUA_BASE] || '');
+}
+
+// Run one highlighting pass, then shield its injected style attrs from later passes.
+function hl(stash: StyleAttrStash, h: string, re: RegExp, repl: string): string {
+  return stashInjectedStyles(h.replace(re, repl), stash);
+}
+
+/* ============================================================
    TYPES & CONSTANTS
    ============================================================ */
 
@@ -393,141 +442,142 @@ function FileOperationView({ toolCall, onClose }: { toolCall: ToolCallDetail; on
 }
 
 /* ── Multi-Language Syntax Highlighter ─────────────────────────────── */
-function highlightLine(line: string, ext: string): string {
-  let h = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+export function highlightLine(line: string, ext: string): string {
+  const h = esc(line);
   if (!h.trim()) return h;
 
-  if (ext === 'py') return highlightPython(h);
-  if (['js', 'jsx', 'ts', 'tsx'].includes(ext)) return highlightJS(h);
-  if (['css', 'scss'].includes(ext)) return highlightCSS(h);
-  if (['html', 'htm'].includes(ext)) return highlightHTML(h);
-  if (ext === 'json') return highlightJSON(h);
-  if (['sh', 'bash', 'zsh'].includes(ext)) return highlightShell(h);
-  
+  const stash: StyleAttrStash = [];
+  if (ext === 'py') return highlightPython(h, stash);
+  if (['js', 'jsx', 'ts', 'tsx'].includes(ext)) return highlightJS(h, stash);
+  if (['css', 'scss'].includes(ext)) return highlightCSS(h, stash);
+  if (['html', 'htm'].includes(ext)) return highlightHTML(h, stash);
+  if (ext === 'json') return highlightJSON(h, stash);
+  if (['sh', 'bash', 'zsh'].includes(ext)) return highlightShell(h, stash);
+
   // Generic fallback
-  return highlightGeneric(h);
+  return highlightGeneric(h, stash);
 }
 
-function highlightPython(line: string): string {
+function highlightPython(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
   // Strings
-  h = h.replace(/(""".*""")|('''.*''')|("[^"]*")|('[^']*')/g, '<span style="color: #98c379">$1</span>');
+  h = hl(stash, h, /(""".*""")|('''.*''')|(&quot;.*?&quot;)|('[^']*')/g, '<span style="color: #98c379">$1</span>');
   // Keywords
   const kw = /\b(import|from|as|def|class|return|if|elif|else|for|while|try|except|finally|with|yield|lambda|raise|assert|del|global|nonlocal|pass|continue|break|and|or|not|in|is|None|True|False)\b/g;
-  h = h.replace(kw, '<span style="color: #c678dd">$1</span>');
+  h = hl(stash, h, kw, '<span style="color: #c678dd">$1</span>');
   // Builtins
   const bi = /\b(print|len|range|enumerate|zip|map|filter|sorted|open|str|int|float|list|dict|set|tuple|type|isinstance|hasattr|getattr|super|self|cls)\b/g;
-  h = h.replace(bi, '<span style="color: #61afef">$1</span>');
+  h = hl(stash, h, bi, '<span style="color: #61afef">$1</span>');
   // Numbers
-  h = h.replace(/\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
+  h = hl(stash, h, /\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
   // Functions
-  h = h.replace(/\b(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
-  return h;
+  h = hl(stash, h, /\b(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightJS(line: string): string {
+function highlightJS(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
-  h = h.replace(/(\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
   // Strings
-  const str = /(`[^`]*`)|("[^"]*")|('[^']*')/g;
-  h = h.replace(str, '<span style="color: #98c379">$1</span>');
+  const str = /(`[^`]*`)|(&quot;.*?&quot;)|('[^']*')/g;
+  h = hl(stash, h, str, '<span style="color: #98c379">$1</span>');
   // Template literals interpolation
-  h = h.replace(/(\\\$\{[^}]*\})/g, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, /(\\\$\{[^}]*\})/g, '<span style="color: #e06c75">$1</span>');
   // Keywords
   const kw = /\b(import|export|from|default|const|let|var|function|class|extends|implements|interface|type|enum|namespace|module|return|if|else|for|while|do|switch|case|break|continue|try|catch|finally|throw|new|this|typeof|instanceof|void|delete|in|of|async|await|yield|get|set|static|public|private|protected|as|declare|readonly)\b/g;
-  h = h.replace(kw, '<span style="color: #c678dd">$1</span>');
+  h = hl(stash, h, kw, '<span style="color: #c678dd">$1</span>');
   // Types
   const types = /\b(string|number|boolean|any|void|null|undefined|object|Array|Promise|React|Record|Map|Set|Date|Error|RegExp|JSON|console|window|document|Math)\b/g;
-  h = h.replace(types, '<span style="color: #e5c07b">$1</span>');
+  h = hl(stash, h, types, '<span style="color: #e5c07b">$1</span>');
   // JSX tags
   if (h.includes('<')) {
-    h = h.replace(/&lt;(\/?)(\w+)/g, '&lt;$1<span style="color: #e06c75">$2</span>');
-    h = h.replace(/(\w+)=/g, '<span style="color: #d19a66">$1</span>=');
+    h = hl(stash, h, /&lt;(\/?)(\w+)/g, '&lt;$1<span style="color: #e06c75">$2</span>');
+    h = hl(stash, h, /(\w+)=/g, '<span style="color: #d19a66">$1</span>=');
   }
   // Properties
-  h = h.replace(/(\w+)(?=:)/g, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, /(\w+)(?=:)/g, '<span style="color: #e06c75">$1</span>');
   // Numbers
-  h = h.replace(/\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
+  h = hl(stash, h, /\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
   // Functions
-  h = h.replace(/\b(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
-  return h;
+  h = hl(stash, h, /\b(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightCSS(line: string): string {
+function highlightCSS(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
-  h = h.replace(/(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
   // Selectors
-  h = h.replace(/^(\s*[.#]\w+)/, '<span style="color: #e06c75">$1</span>');
-  h = h.replace(/@\w+/g, '<span style="color: #c678dd">$&</span>');
+  h = hl(stash, h, /^(\s*[.#]\w+)/, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, /@\w+/g, '<span style="color: #c678dd">$&</span>');
   // Properties
   const prop = /([\w-]+)(?=\s*:)/g;
-  h = h.replace(prop, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, prop, '<span style="color: #e06c75">$1</span>');
   // Values (colors, px, rem, etc)
-  h = h.replace(/(#[0-9a-fA-F]{3,8})/g, '<span style="color: #98c379">$1</span>');
-  h = h.replace(/(\d+(px|rem|em|%|vh|vw|s|ms|deg|fr|pt|cm|mm|in))/g, '<span style="color: #d19a66">$1</span>');
+  h = hl(stash, h, /(#[0-9a-fA-F]{3,8})/g, '<span style="color: #98c379">$1</span>');
+  h = hl(stash, h, /(\d+(px|rem|em|%|vh|vw|s|ms|deg|fr|pt|cm|mm|in))/g, '<span style="color: #d19a66">$1</span>');
   // Strings
-  h = h.replace(/("[^"]*")|('[^']*')/g, '<span style="color: #98c379">$1</span>');
-  return h;
+  h = hl(stash, h, /(&quot;.*?&quot;)|('[^']*')/g, '<span style="color: #98c379">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightHTML(line: string): string {
+function highlightHTML(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(&lt;!--[\s\S]*?--&gt;)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(&lt;!--[\s\S]*?--&gt;)/gm, '<span style="color: #5c6370">$1</span>');
   // Tags
-  h = h.replace(/&lt;(\/?)(\w+)/g, '&lt;$1<span style="color: #e06c75">$2</span>');
-  h = h.replace(/(\/?)\s*&gt;/g, '$1<span style="color: #e06c75">&gt;</span>');
+  h = hl(stash, h, /&lt;(\/?)(\w+)/g, '&lt;$1<span style="color: #e06c75">$2</span>');
+  h = hl(stash, h, /(\/?)\s*&gt;/g, '$1<span style="color: #e06c75">&gt;</span>');
   // Attributes
-  h = h.replace(/\b(\w+)(?==)/g, '<span style="color: #d19a66">$1</span>');
+  h = hl(stash, h, /\b(\w+)(?==)/g, '<span style="color: #d19a66">$1</span>');
   // Strings
-  h = h.replace(/("[^"]*")|('[^']*')/g, '<span style="color: #98c379">$1</span>');
-  return h;
+  h = hl(stash, h, /(&quot;.*?&quot;)|('[^']*')/g, '<span style="color: #98c379">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightJSON(line: string): string {
+function highlightJSON(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Keys
-  h = h.replace(/("[^"]*")(?=\s*:)/g, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, /(&quot;.*?&quot;)(?=\s*:)/g, '<span style="color: #e06c75">$1</span>');
   // Strings
-  h = h.replace(/("[^"]*")/g, '<span style="color: #98c379">$1</span>');
+  h = hl(stash, h, /(&quot;.*?&quot;)/g, '<span style="color: #98c379">$1</span>');
   // Numbers
-  h = h.replace(/\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
+  h = hl(stash, h, /\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
   // Booleans/null
   const kw = /\b(true|false|null)\b/g;
-  h = h.replace(kw, '<span style="color: #c678dd">$1</span>');
-  return h;
+  h = hl(stash, h, kw, '<span style="color: #c678dd">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightShell(line: string): string {
+function highlightShell(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
   // Variables
-  h = h.replace(/(\$\w+)/g, '<span style="color: #e06c75">$1</span>');
+  h = hl(stash, h, /(\$\w+)/g, '<span style="color: #e06c75">$1</span>');
   // Builtins
   const builtins = /\b(echo|cd|ls|mkdir|rm|cp|mv|cat|grep|awk|sed|cut|sort|uniq|head|tail|find|chmod|chown|sudo|apt|yum|brew|curl|wget|git|docker|python|python3|node|npm|npx|yarn|pip|pip3)\b/g;
-  h = h.replace(builtins, '<span style="color: #61afef">$1</span>');
+  h = hl(stash, h, builtins, '<span style="color: #61afef">$1</span>');
   // Strings
-  h = h.replace(/("[^"]*")|('[^']*')/g, '<span style="color: #98c379">$1</span>');
-  return h;
+  h = hl(stash, h, /(&quot;.*?&quot;)|('[^']*')/g, '<span style="color: #98c379">$1</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
-function highlightGeneric(line: string): string {
+function highlightGeneric(line: string, stash: StyleAttrStash): string {
   let h = line;
   // Comments
-  h = h.replace(/(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
-  h = h.replace(/(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(\/\/.*$)/gm, '<span style="color: #5c6370">$1</span>');
+  h = hl(stash, h, /(#.*)$/gm, '<span style="color: #5c6370">$1</span>');
   // Strings
-  h = h.replace(/("[^"]*")|('[^']*')/g, '<span style="color: #98c379">$1</span>');
+  h = hl(stash, h, /(&quot;.*?&quot;)|('[^']*')/g, '<span style="color: #98c379">$1</span>');
   // Numbers
-  h = h.replace(/\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
-  return h;
+  h = hl(stash, h, /\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$&</span>');
+  return unstashInjectedStyles(h, stash);
 }
 
 function StatusDot({ status }: { status: string }) {
@@ -1651,21 +1701,25 @@ interface ParsedFileDiff {
   rawContent?: string;
 }
 
+/* CU-UI-01: esc() runs FIRST so raw model text can never reach innerHTML;
+   only the trusted tags injected below are literal HTML. Later passes cannot
+   match inside the injected style="..." attributes (they contain no
+   backticks/asterisks/underscores). */
+export function formatInline(raw: string): string {
+  let f = esc(raw);
+  f = f.replace(/`(.*?)`/g, '<code style="background-color: rgba(255,255,255,0.08); padding: 2px 6px; border-radius: 4px; font-family: monospace; font-size: 11px; color: #38bdf8;">$1</code>');
+  f = f.replace(/\*\*(.*?)\*\*/g, '<strong style="color: #f0f6fc;">$1</strong>');
+  f = f.replace(/__(.*?)__/g, '<strong style="color: #f0f6fc;">$1</strong>');
+  f = f.replace(/\*(.*?)\*/g, '<em style="color: #c9d1d9;">$1</em>');
+  f = f.replace(/_(.*?)_/g, '<em style="color: #c9d1d9;">$1</em>');
+  return f;
+}
+
 function FileMarkdownViewer({ content }: { content: string }) {
   const lines = (content || '').split('\n');
   const elements: React.ReactNode[] = [];
   let inCodeBlock = false;
   let codeBlockContent: string[] = [];
-
-  const formatInline = (text: string) => {
-    let f = text;
-    f = f.replace(/`(.*?)`/g, '<code style="background-color: rgba(255,255,255,0.08); padding: 2px 6px; border-radius: 4px; font-family: monospace; font-size: 11px; color: #38bdf8;">$1</code>');
-    f = f.replace(/\*\*(.*?)\*\*/g, '<strong style="color: #f0f6fc;">$1</strong>');
-    f = f.replace(/__(.*?)__/g, '<strong style="color: #f0f6fc;">$1</strong>');
-    f = f.replace(/\*(.*?)\*/g, '<em style="color: #c9d1d9;">$1</em>');
-    f = f.replace(/_(.*?)_/g, '<em style="color: #c9d1d9;">$1</em>');
-    return f;
-  };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -2096,32 +2150,33 @@ function CodeEditorPreview({ toolCall }: { toolCall: ToolCallDetail }) {
 
   // Simple syntax highlighter matching One Dark theme
   const highlightSyntax = (code: string, fileName: string): string => {
-    let h = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    
+    const h0 = esc(code);
+    const stash: StyleAttrStash = [];
+
     // Keywords (purple)
     const keywords = /\b(import|export|from|const|let|var|function|return|if|else|for|while|class|interface|type|extends|implements|async|await|try|catch|throw|new|this|typeof|instanceof|default|as|yield|void|delete|in|of)\b/g;
-    h = h.replace(keywords, '<span style="color: #c678dd">$1</span>');
-    
+    let h = hl(stash, h0, keywords, '<span style="color: #c678dd">$1</span>');
+
     // Types (yellow/orange)
     const types = /\b(string|number|boolean|any|void|null|undefined|object|Array|Promise|React|ComponentProps|ReactNode|JSX|Element|boolean|Record|Map|Set|Date|Error|RegExp)\b/g;
-    h = h.replace(types, '<span style="color: #e5c07b">$1</span>');
-    
+    h = hl(stash, h, types, '<span style="color: #e5c07b">$1</span>');
+
     // Strings (green)
-    h = h.replace(/("[^"]*"|'[^']*'|`[^`]*`)/g, '<span style="color: #98c379">$1</span>');
-    
+    h = hl(stash, h, /(&quot;.*?&quot;|'[^']*'|`[^`]*`)/g, '<span style="color: #98c379">$1</span>');
+
     // Comments (gray)
-    h = h.replace(/(\/\/.*$|\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
-    
+    h = hl(stash, h, /(\/\/.*$|\/\*[\s\S]*?\*\/)/gm, '<span style="color: #5c6370">$1</span>');
+
     // Functions (blue)
-    h = h.replace(/(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
-    
+    h = hl(stash, h, /(\w+)(?=\()/g, '<span style="color: #61afef">$1</span>');
+
     // Numbers (orange)
-    h = h.replace(/\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$1</span>');
-    
+    h = hl(stash, h, /\b\d+\.?\d*\b/g, '<span style="color: #d19a66">$1</span>');
+
     // Properties (red)
-    h = h.replace(/(\w+)(?=:)/g, '<span style="color: #e06c75">$1</span>');
-    
-    return h;
+    h = hl(stash, h, /(\w+)(?=:)/g, '<span style="color: #e06c75">$1</span>');
+
+    return unstashInjectedStyles(h, stash);
   };
 
   return (

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -3607,6 +3607,9 @@ export default function ChatPage() {
                     truncatedTools: truncatedTools ?? undefined,
                     schemaTokenSavings: schemaTokenSavings ?? undefined,
                 });
+                // NOTE: Usage persistence/analytics recording happens in the main process
+                // (agent-runtime/call_model/brain forward acp:usage upstream). Recording here
+                // too would double-count every row.
             });
             acpApi.onSurfaceAction((data: any) => {
                 if (data?.conversationId && data.conversationId !== activeConversationIdRef.current) return;
@@ -3717,7 +3720,9 @@ export default function ChatPage() {
         })();
     }, [activeConversationId, selectedModel, availableModels, pursueGoalMode, applyLiveToolUpdate]);
 
-    const saveConversation = useCallback(async (msgs: Message[], isFullSave: boolean = false) => {
+    const saveConversation = useCallback(async (msgs: Message[], isFullSave: boolean = true) => {
+        // Full-snapshot saves of empty lists are not a supported UI flow — bail unconditionally
+        // to prevent an accidental mass-delete of all messages at the store level.
         if (msgs.length === 0) return;
         // Use the ref for synchronous reads — avoids duplicate IDs when called
         // multiple times before React flushes the state update.
@@ -4319,6 +4324,9 @@ export default function ChatPage() {
                         truncatedTools: truncatedTools ?? undefined,
                         schemaTokenSavings: schemaTokenSavings ?? undefined,
                     });
+                    // NOTE: Usage persistence/analytics recording happens in the main process
+                    // (agent-runtime/call_model/brain forward acp:usage upstream). Recording here
+                    // too would double-count every row.
                 });
                 api.onOptima(({ event, details, conversationId }: { event: string; details: string; conversationId?: string }) => {
                     if (conversationId && conversationId !== activeConversationIdRef.current) return;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -312,6 +312,10 @@
   --color-bg-hover: rgba(0, 0, 0, 0.04);
   --color-bg-active: rgba(0, 0, 0, 0.08);
   --color-bg-selected: rgba(0, 0, 0, 0.06);
+  --color-bg-surface-hover: rgba(0, 0, 0, 0.05);
+
+  /* Scrim / Overlay Dim */
+  --scrim: rgba(0, 0, 0, 0.45);
 
   /* Border Colors */
   --color-border: #e8e6d9;
@@ -348,6 +352,14 @@
   --color-info-light: #60a5fa;
   --color-info-dim: rgba(59, 130, 246, 0.15);
 
+  /* Diff Colors (GitHub-style; values mirror diff-viewer fallbacks) */
+  --diff-add-bg: rgba(46, 160, 67, 0.15);
+  --diff-del-bg: rgba(248, 81, 73, 0.15);
+  --diff-add-text: #1a7f37;
+  --diff-del-text: #cf222e;
+  --diff-add-text-dark: #3fb950;
+  --diff-del-text-dark: #f85149;
+
   /* Agent / Tool Colors */
   --color-analysing: #a1a1aa;
   --color-tool-call: var(--color-accent);
@@ -375,30 +387,6 @@
   --interrupted-btn-border: rgba(0, 0, 0, 0.08);
   --interrupted-btn-text: #111827;
   --interrupted-btn-hover-bg: rgba(0, 0, 0, 0.10);
-
-  /* Sidebar Theme Variables (Light Theme) */
-  --sidebar-bg: #f5f4f0;
-  --sidebar-border: #e8e6d9;
-  --sidebar-btn-color: #8a8886;
-  --sidebar-btn-hover-color: #111111;
-  --sidebar-brand-text: #111111;
-  --sidebar-text-primary: #111111;
-  --sidebar-text-secondary: #4a4846;
-  --sidebar-text-tertiary: #8a8886;
-  --sidebar-bg-hover: rgba(0, 0, 0, 0.04);
-  --sidebar-bg-selected: rgba(0, 0, 0, 0.06);
-  --sidebar-bg-active: rgba(0, 0, 0, 0.08);
-  --sidebar-avatar-bg: #eae8e1;
-  --sidebar-avatar-border: #dcdad0;
-  --sidebar-limit-text: #8a8886;
-  --sidebar-project-text: #666666;
-
-  --sidebar-settings-bg: rgba(0, 0, 0, 0.03);
-  --sidebar-settings-border: rgba(0, 0, 0, 0.06);
-  --sidebar-settings-text: #8a8886;
-  --sidebar-settings-hover-bg: rgba(0, 0, 0, 0.06);
-  --sidebar-settings-hover-border: rgba(0, 0, 0, 0.15);
-  --sidebar-settings-hover-text: #111111;
 
   /* Typography System */
   --font-sans: 'Figtree', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -514,9 +502,6 @@
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
-  /* Scrollbar */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.10) transparent;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --muted: oklch(0.97 0 0);
@@ -539,7 +524,6 @@
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
   /* Sidebar Theme Variables */
@@ -1054,6 +1038,10 @@ a:hover {
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 
+  /* Scrollbar */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.10) transparent;
+
   /* Background Colors — Dark Theme (Claude-inspired charcoal) */
   --color-bg-base: #0f0e0c;
   --color-bg-surface: #181714;
@@ -1068,6 +1056,10 @@ a:hover {
   --color-bg-hover: rgba(255, 255, 255, 0.04);
   --color-bg-active: rgba(255, 255, 255, 0.08);
   --color-bg-selected: rgba(255, 255, 255, 0.06);
+  --color-bg-surface-hover: rgba(255, 255, 255, 0.05);
+
+  /* Scrim / Overlay Dim */
+  --scrim: rgba(0, 0, 0, 0.60);
 
   /* Border Colors */
   --color-border: #333029;

--- a/src/components/files/FileViewerModal.tsx
+++ b/src/components/files/FileViewerModal.tsx
@@ -50,6 +50,14 @@ export function PDFViewer({ file }: { file: { name: string; path: string } }) {
     const [showAppDropdown, setShowAppDropdown] = useState(false);
     const appDropdownRef = useRef<HTMLDivElement>(null);
 
+    // NR-UI-09: mirror the URL in a ref so cleanup revokes the CURRENT blob
+    // url, not the stale state value captured when this effect was created.
+    const pdfBlobUrlRef = useRef<string | null>(null);
+    const updatePdfBlobUrl = (url: string | null) => {
+        pdfBlobUrlRef.current = url;
+        setPdfBlobUrl(url);
+    };
+
     // Fetch registered default opener apps (VS Code, Acrobat, Edge, etc.)
     useEffect(() => {
         if (!file?.path) return;
@@ -98,10 +106,10 @@ export function PDFViewer({ file }: { file: { name: string; path: string } }) {
                             const byteArray = new Uint8Array(byteNumbers);
                             const blob = new Blob([byteArray], { type: 'application/pdf' });
                             const bUrl = URL.createObjectURL(blob);
-                            if (isMounted) setPdfBlobUrl(bUrl);
+                            if (isMounted) updatePdfBlobUrl(bUrl);
                         }
                     } catch (e) {
-                        if (isMounted) setPdfBlobUrl(imgRes.dataUrl);
+                        if (isMounted) updatePdfBlobUrl(imgRes.dataUrl);
                     }
                     if (isMounted) setLoadingPdf(false);
                     return;
@@ -111,7 +119,7 @@ export function PDFViewer({ file }: { file: { name: string; path: string } }) {
                 const cleanPath = file.path.replace(/\\/g, '/');
                 const fallbackUrl = `file:///${cleanPath.startsWith('/') ? cleanPath.slice(1) : cleanPath}`;
                 if (isMounted) {
-                    setPdfBlobUrl(fallbackUrl);
+                    updatePdfBlobUrl(fallbackUrl);
                     setLoadingPdf(false);
                 }
             } catch (err) {
@@ -127,8 +135,9 @@ export function PDFViewer({ file }: { file: { name: string; path: string } }) {
 
         return () => {
             isMounted = false;
-            if (pdfBlobUrl && pdfBlobUrl.startsWith('blob:')) {
-                URL.revokeObjectURL(pdfBlobUrl);
+            const currentUrl = pdfBlobUrlRef.current;
+            if (currentUrl && currentUrl.startsWith('blob:')) {
+                URL.revokeObjectURL(currentUrl);
             }
         };
     }, [file?.path]);
@@ -617,7 +626,7 @@ export function MarkdownViewer({ content }: { content: string }) {
             if (line.trim().startsWith('- ') || line.trim().startsWith('* ')) {
                 const itemContent = line.trim().substring(2);
                 elements.push(
-                    <li key={`li-${i}`} style={{ marginLeft: 20, margin: '6px 0', fontSize: 14, color: 'var(--color-text-primary)', lineHeight: 1.6 }}
+                    <li key={`li-${i}`} style={{ margin: '6px 0 6px 20px', fontSize: 14, color: 'var(--color-text-primary)', lineHeight: 1.6 }}
                         dangerouslySetInnerHTML={{ __html: formatInline(itemContent) }}
                     />
                 );
@@ -661,6 +670,18 @@ export function MarkdownViewer({ content }: { content: string }) {
 }
 
 // ── 3. EXCEL & CSV VIEWER ───────────────────────────────────────────
+// NR-UI-10: bijective base-26 column labels (A..Z, AA..ZZ, ...).
+// String.fromCharCode(65 + i) emits punctuation past column Z.
+const excelColumnLabel = (index: number): string => {
+    let label = '';
+    let n = index;
+    do {
+        label = String.fromCharCode(65 + (n % 26)) + label;
+        n = Math.floor(n / 26) - 1;
+    } while (n >= 0);
+    return label;
+};
+
 function ExcelViewer({ filename, content }: { filename: string; content: string | null }) {
     const { theme } = useTheme();
     const isDark = theme === 'dark';
@@ -699,7 +720,7 @@ function ExcelViewer({ filename, content }: { filename: string; content: string 
         });
     }, [parsedData, filterQuery]);
 
-    const columns = Array.from({ length: Math.max(parsedData[0]?.length || 10, 10) }, (_, i) => String.fromCharCode(65 + i));
+    const columns = Array.from({ length: Math.max(parsedData[0]?.length || 10, 10) }, (_, i) => excelColumnLabel(i));
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%', backgroundColor: 'var(--color-bg-base)', minWidth: 0, minHeight: 0 }}>


### PR DESCRIPTION
## Problem

Installed macOS builds (DMG) open to a **grey window, then quit**. Reproducible from v1.1.3 onward on current macOS (incl. 26/27 betas). `npm run dev` from a fresh clone works fine, which made this hard to pin down.

Terminal shows the renderer/GPU helpers dying at `dyld`:

```
dyld[...]: Library not loaded: @rpath/Electron Framework.framework/Electron Framework
  Reason: code signature in ... '/Electron Framework' not valid for use in process:
  mapping process and mapped file (non-platform) have different Team IDs
...
ERROR:content/browser/gpu/gpu_process_host.cc] GPU process exited unexpectedly
FATAL:gpu_data_manager_impl_private.cc(417)] GPU process isn't usable. Goodbye.
```

## Root cause

The `mac` config sets `hardenedRuntime: true`, but CI has no signing certificate, so electron-builder signs the bundle **ad-hoc** while applying the **hardened runtime** flag.

Hardened runtime enables *library validation*: the loading process and the mapped library must share a Team ID. Two independently ad-hoc-signed binaries never do — each ad-hoc binary is its own anonymous identity. So every helper process (GPU / Renderer / Network) is killed by dyld the moment it maps `Electron Framework`, and Chromium aborts with "GPU process isn't usable".

Dev mode is unaffected because `electron .` runs Electron's stock Developer-ID-signed binaries, which are never re-signed — consistent team, validation passes.

## Fix

- Set `hardenedRuntime: false` — correct for unsigned/ad-hoc release builds; hardened runtime only matters for notarized Developer-ID builds.
- Add an `afterSign` hook (`scripts/after-sign-mac.cjs`) as a safety net: walks the bundle deepest-first and re-signs any remaining ad-hoc + hardened-runtime component without the runtime flag. It **skips entirely** when a real identity is configured (`CSC_LINK`/`CSC_NAME`), so future properly-signed/notarized builds are untouched.

## Verification

On a machine where the shipped v1.2.0 DMG reliably crashes:

| build | helpers | result |
|---|---|---|
| as-shipped (adhoc + `runtime` flag) | GPU/Renderer/Network dyld-abort within ~5 s | grey screen → quit |
| after hook (adhoc, no `runtime`) | GPU + network helpers stay alive | window renders, app stable |

`codesign --verify --deep --strict` passes post-hook; helper flags go from `0x10002(adhoc,runtime)` to `0x2(adhoc)`.

---

## Update — scope expanded: Checkpoint 1 of the hardening & optimization campaign

The signing fix above remains the foundation of this PR (unchanged, first commits). On top of it, this branch now carries **Checkpoint 1** of a much bigger audit-driven campaign: a 663-finding full-codebase audit (~105 findings addressed in this checkpoint), with further checkpoints to follow.

### What checkpoint 1 delivers, in numbers

| Area | Result |
|---|---|
| **Local AI (Ollama / LM Studio)** | Eliminates model cold-reloads between agentic turns (`keep_alive:'30m'` — up to **~60 s saved per idle gap**); fixes the reported `[ollama] HTTP 400` tool-schema rejection class **entirely** (recursive sanitizer: property-level `required` booleans at any depth, `items`/`anyOf`/`oneOf`/`allOf`, union types); removes `fetch failed` on default configs (`localhost`→`127.0.0.1` across all 8 outbound paths); thinking models now **stream reasoning instead of silent gaps** on 4 provider paths |
| **Stability** | App quit now **guaranteed ≤8 s** (previously could hang forever); renderer crashes **auto-recover** (reload ×3 → relaunch) instead of grey-screening; main-process exceptions persist breadcrumbs instead of silent death; scheduler can no longer freeze the process; DB init race/deadlock fixed |
| **Security** | **14 vulnerability classes closed**: IPC path-traversal R/W/delete (symlink/TOCTOU-hardened), PowerShell/docker/shell injection (5 sinks), extension-bridge CSRF + cross-site-WS hijack, tool-approval bypass via metacharacters/redirection, unprompted Windows host execution (incl. VM-down fallback holes), SSRF (redirect-aware + DNS-resolved private-range checks), arbitrary file launch, unconfirmed account wipe |
| **UI correctness** | XSS sinks closed (10 sinks across tool-detail/document renderers); dark-theme invisibility fixed via semantic-token migration; HITL approval cards no longer die after the first send; PDF blob leaks, Excel column labels, list-indent bugs |
| **Harness** | Restores the entire Navis system prompt (**~11 KB was silently never loading**); SOUL.md double-injection deduped; conversation history no longer truncated by incremental saves |

**Verification:** `tsc` clean on both configs; full Vitest suite green vs baseline with **+35 new regression tests** across 11 new suites (every fix covered); bridge hardening verified by live probes. No behavior changes for legitimate flows beyond explicitly flagged safety gates.

**Next checkpoints:** renderer streaming performance program (ChatPage split, incremental markdown), context-pipeline redesign, ~150 MB packaging reduction, macOS TCC guidance flows + Retina coordinate overhaul.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application signing for ad-hoc signed builds to prevent hardened runtime issues.
  * Automatically repairs affected embedded components during signing and re-seals the application.
  * Provides clearer reporting when signing repairs fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
